### PR TITLE
patch for app creation, now accepting team.

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -18,8 +18,9 @@ func CreateAppHandler(params apps.CreateAppParams, principal interface{}) middle
 		Scale: params.Body.Scale,
 	}
 	sa := storage.Application{
-		Name:  *params.Body.Name,
-		Scale: int16(*params.Body.Scale),
+		Name:   *params.Body.Name,
+		Scale:  int16(*params.Body.Scale),
+		TeamID: uint(params.TeamID),
 	}
 	if err := storage.DB.Create(&sa).Error; err != nil {
 		log.Printf("CreateAppHandler failed: %s\n", err)

--- a/cli/cmd/app.go
+++ b/cli/cmd/app.go
@@ -24,10 +24,26 @@ import (
 
 // createAppCmd represents the app command
 var createAppCmd = &cobra.Command{
-	Use:   "app",
+	Use:   "app [app_name]",
 	Short: "Create an app",
+	Long: `Create a new application for the team.
+
+The application name is always required, but team name is only required if you are part of more than one.
+Example:
+
+	$ teresa create app my_app_name
+
+or
+
+	$ teresa create app my_app_name --team my_team
+
+You can also provide in how many pods you want your app running.
+Like in the example bellow, let's run in 4 pods:
+
+	$ teresa create app my_app_name --team my_team --scale 4
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if appNameFlag == "" {
+		if len(args) == 0 {
 			return newInputError("app name is required")
 		}
 		if appScaleFlag == 0 {
@@ -35,7 +51,8 @@ var createAppCmd = &cobra.Command{
 		}
 
 		tc := NewTeresa()
-		app, err := tc.CreateApp(appNameFlag, int64(appScaleFlag))
+		teamID := tc.GetTeamID(teamNameFlag)
+		app, err := tc.CreateApp(args[0], int64(appScaleFlag), teamID)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -209,8 +226,8 @@ The team name is only required if you are part of more than one.
 
 func init() {
 	createCmd.AddCommand(createAppCmd)
-	createAppCmd.Flags().StringVar(&appNameFlag, "name", "", "app name [required]")
-	createAppCmd.Flags().IntVar(&appScaleFlag, "scale", 1, "replicas [required]")
+	createAppCmd.Flags().StringVar(&teamNameFlag, "team", "", "team name")
+	createAppCmd.Flags().IntVar(&appScaleFlag, "scale", 1, "replicas")
 
 	getCmd.AddCommand(getAppCmd)
 	getAppCmd.Flags().StringVar(&appNameFlag, "app", "", "app name [required]")

--- a/cli/cmd/teresaclient.go
+++ b/cli/cmd/teresaclient.go
@@ -117,8 +117,9 @@ func (tc TeresaClient) DeleteTeam(ID int64) error {
 }
 
 // CreateApp creates an user
-func (tc TeresaClient) CreateApp(name string, scale int64) (app *models.App, err error) {
+func (tc TeresaClient) CreateApp(name string, scale int64, teamID int64) (app *models.App, err error) {
 	params := apps.NewCreateAppParams()
+	params.TeamID = teamID
 	params.WithBody(&models.App{Name: &name, Scale: &scale})
 	r, err := tc.teresa.Apps.CreateApp(params, tc.apiKeyAuthFunc)
 	if err != nil {
@@ -190,6 +191,25 @@ func (tc TeresaClient) GetAppInfo(teamName, appName string) (appInfo AppInfo) {
 	if appInfo.TeamID == 0 || appInfo.AppID == 0 {
 		log.Fatalf("Invalid Team [%s] or App [%s]\n", teamName, appName)
 	}
+	return
+}
+
+// GetTeamID returns teamID from team_name
+func (tc TeresaClient) GetTeamID(teamName string) (teamID int64) {
+	me, err := tc.Me()
+	if err != nil {
+		log.Fatalf("unable to get user information: %s", err)
+	}
+	if len(me.Teams) > 1 && teamName == "" {
+		log.Fatalln("User is in more than one team and provided none")
+	}
+	for _, t := range me.Teams {
+		if teamName == "" || *t.Name == teamName {
+			return t.ID
+		}
+	}
+
+	log.Fatalf("Invalid Team [%s]\n", teamName)
 	return
 }
 


### PR DESCRIPTION
Now user must provide the name of the team when creating and app.
Also i changed the command for this model:

```
$  teresa create app myapp --team b2b
```

Now the name of the app is an arg, not anymore a flag. What do you think?

Card: https://trello.com/c/ra5BmL9G/48-bug-create-app-precisa-aceitar-time
