### PR TITLE
create app and namespaces+secret on kubernetes

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -9,6 +9,14 @@ import (
 	"github.com/luizalabs/paas/api/models/storage"
 	"github.com/luizalabs/paas/api/restapi/operations/apps"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+const (
+	storageRegion     = "us-east-1"
+	storageBucketName = "teresa-staging"
+	storageAccessKey  = "AKIAIUARH63XWZUMCFWA"
+	storageSecretKey  = "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"
 )
 
 // CreateAppHandler create apps
@@ -22,10 +30,60 @@ func CreateAppHandler(params apps.CreateAppParams, principal interface{}) middle
 		Scale:  int16(*params.Body.Scale),
 		TeamID: uint(params.TeamID),
 	}
+	// save to DB
 	if err := storage.DB.Create(&sa).Error; err != nil {
 		log.Printf("CreateAppHandler failed: %s\n", err)
 		return apps.NewCreateAppDefault(500)
 	}
+
+	// get app and team info
+	if storage.DB.Where(&storage.Application{TeamID: uint(params.TeamID)}).Preload("Team").First(&sa).RecordNotFound() {
+		log.Println("app info not found")
+		return apps.NewCreateAppDefault(500)
+	}
+
+	// namespaces yaml
+	nsy := api.Namespace{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name: getNamespaceName(sa.Team.Name, sa.Name),
+		},
+	}
+	// creating namespace
+	ns, err := k8sClient.Namespaces().Create(&nsy)
+	if err != nil {
+		log.Printf("Error when create the namespace [%s] for the app. Err: %s\n", nsy.GetName(), err)
+		return apps.NewCreateAppDefault(500)
+	}
+
+	// secret yaml
+	svcy := api.Secret{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		Type: api.SecretTypeOpaque,
+		ObjectMeta: api.ObjectMeta{
+			Name:      "s3-storage",
+			Namespace: ns.GetName(),
+		},
+		Data: map[string][]byte{
+			"region":         []byte(storageRegion),
+			"builder-bucket": []byte(storageBucketName),
+			"accesskey":      []byte(storageAccessKey),
+			"secretkey":      []byte(storageSecretKey),
+		},
+	}
+	// creating secret
+	_, err = k8sClient.Secrets(ns.GetName()).Create(&svcy)
+	if err != nil {
+		log.Printf("Error creating the storage secret for the namespace [%s] . Err: %s\n", nsy.GetName(), err)
+		return apps.NewCreateAppDefault(500)
+	}
+
 	a.ID = int64(sa.ID)
 	r := apps.NewCreateAppCreated()
 	r.SetPayload(&a)

--- a/api/handlers/deployment.go
+++ b/api/handlers/deployment.go
@@ -101,11 +101,15 @@ func newDeployParams(app *storage.Application) *deployParams {
 		app:  slugify(app.Name),
 		team: slugify(app.Team.Name),
 	}
-	d.namespace = fmt.Sprintf("%s--%s", d.team, d.app)
+	d.namespace = getNamespaceName(d.team, d.app)
 	d.storageIn = fmt.Sprintf("deploys/%s/%s/%s/in/app.tar.gz", d.team, d.app, d.id)
 	d.storageOut = fmt.Sprintf("deploys/%s/%s/%s/out", d.team, d.app, d.id)
 	d.slugPath = fmt.Sprintf("%s/slug.tgz", d.storageOut)
 	return &d
+}
+
+func getNamespaceName(team, app string) string {
+	return fmt.Sprintf("%s--%s", team, app)
 }
 
 // uploadArchiveToStorage uploads a file (AppTarball) to storage (AWS S3)


### PR DESCRIPTION
When creating a new app, also a namespace and secret is created on kubernetes.

The secret is used by the deploy handler to:

> - upload app archive to AWS S3
> - slugbuilder will download this archive to build the app, and after this, upload the slug again to S3  
> - slugrunner will download the slug to run the app
