### PR TITLE
Fix to use sqlite in dev mode

### DIFF
--- a/api/models/storage/models.go
+++ b/api/models/storage/models.go
@@ -113,7 +113,7 @@ func init() {
 	}
 
 	// we got to read the conf from env
-	if env == "PRODUCTION" || err == nil {
+	if env == "PRODUCTION" || (err == nil && conf.Hostname != "") {
 		dialect = "mysql"
 		uri = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", conf.Username, conf.Password, conf.Hostname, conf.Port, conf.Database)
 	} else {


### PR DESCRIPTION
I put this check `conf.Hostname != ""`, so we can use sqlite again.

There is no error when the environment variables doesn't exist, and the api was trying to use mysql always.
