### PR TITLE
changed to get k8s, builder and storage from env vars

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -12,13 +12,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
-const (
-	storageRegion     = "us-east-1"
-	storageBucketName = "teresa-staging"
-	storageAccessKey  = "AKIAIUARH63XWZUMCFWA"
-	storageSecretKey  = "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"
-)
-
 // CreateAppHandler create apps
 func CreateAppHandler(params apps.CreateAppParams, principal interface{}) middleware.Responder {
 	a := models.App{
@@ -71,10 +64,10 @@ func CreateAppHandler(params apps.CreateAppParams, principal interface{}) middle
 			Namespace: ns.GetName(),
 		},
 		Data: map[string][]byte{
-			"region":         []byte(storageRegion),
-			"builder-bucket": []byte(storageBucketName),
-			"accesskey":      []byte(storageAccessKey),
-			"secretkey":      []byte(storageSecretKey),
+			"region":         []byte(builderConfig.AwsRegion),
+			"builder-bucket": []byte(builderConfig.AwsBucket),
+			"accesskey":      []byte(builderConfig.AwsKey),
+			"secretkey":      []byte(builderConfig.AwsSecret),
 		},
 	}
 	// creating secret

--- a/api/k8s/k8s_util.go
+++ b/api/k8s/k8s_util.go
@@ -60,25 +60,8 @@ func BuildSlugbuilderPod(
 	return p
 }
 
-func progress(msg string, interval time.Duration) chan bool {
-	tick := time.Tick(interval)
-	quit := make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-quit:
-				close(quit)
-				return
-			case <-tick:
-				fmt.Println(msg)
-			}
-		}
-	}()
-	return quit
-}
-
 // WaitForPod waits for running stated, among others
-func WaitForPod(c *client.Client, ns, podName string, ticker, interval, timeout time.Duration) error {
+func WaitForPod(c *client.Client, ns, podName string, interval, timeout time.Duration) error {
 	condition := func(pod *api.Pod) (bool, error) {
 		if pod.Status.Phase == api.PodRunning {
 			return true, nil
@@ -91,11 +74,7 @@ func WaitForPod(c *client.Client, ns, podName string, ticker, interval, timeout 
 		}
 		return false, nil
 	}
-
-	quit := progress("...", ticker)
 	err := waitForPodCondition(c, ns, podName, condition, interval, timeout)
-	quit <- true
-	<-quit
 	return err
 }
 


### PR DESCRIPTION
Changed to accept env vars for k8s, storage (only aws for now) and builder timeouts

```
- TERESAK8S_HOST
- TERESAK8S_USERNAME
- TERESAK8S_PASSWORD
- TERESAK8S_INSECURE
- TERESABUILDER_STORAGE_AWS_KEY
- TERESABUILDER_STORAGE_AWS_SECRET
- TERESABUILDER_STORAGE_AWS_REGION
- TERESABUILDER_STORAGE_AWS_BUCKET
- TERESABUILDER_WAIT_POD_TIMEOUT
- TERESABUILDER_WAIT_LB_TIMEOUT
```
