### PR TITLE
limit the size of app name

### DIFF
--- a/pkg/client/cmd/app.go
+++ b/pkg/client/cmd/app.go
@@ -17,6 +17,9 @@ import (
 	"golang.org/x/net/context"
 )
 
+//Service name component must be a valid RFC 1035 name
+const appNameLimit = 63
+
 var appCmd = &cobra.Command{
 	Use:   "app",
 	Short: "Everything about apps",
@@ -56,6 +59,9 @@ func createApp(cmd *cobra.Command, args []string) {
 		return
 	}
 	name := args[0]
+	if len(name) > appNameLimit {
+		client.PrintErrorAndExit("Invalid app name (max %d characters)", appNameLimit)
+	}
 
 	team, err := cmd.Flags().GetString("team")
 	if err != nil || team == "" {


### PR DESCRIPTION
This is for avoiding problem with kube-dns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa/282)
<!-- Reviewable:end -->
