### PR TITLE
remove `max-cpu` and `max-memory` flags of app create command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [NEXT_RELEASE]
 ### Added
 - [client] App name length validation
+- [client] Remove `max-cpu` and `max-memory` flags of create app command
 
 ## [0.5.0] - 2017-08-15
 ### Changed

--- a/pkg/client/cmd/app.go
+++ b/pkg/client/cmd/app.go
@@ -46,10 +46,10 @@ The app name must follow this rules:
   $ teresa app create foo --team bar --scale-min 2 --scale-max 10 --scale-cpu 70
 
   With specific cpu and memory size...
-  $ teresa create foo --team bar --cpu 200m --max-cpu 500m --memory 512Mi --max-memory 1Gi
+  $ teresa create foo --team bar --cpu 200m --memory 512Mi
 
   With all flags...
-  $ teresa app create foo --team bar --cpu 200m --max-cpu 500m --memory 512Mi --max-memory 1Gi --scale-min 2 --scale-max 10 --scale-cpu 70 --process-type web`,
+  $ teresa app create foo --team bar --cpu 200m --memory 512Mi --scale-min 2 --scale-max 10 --scale-cpu 70 --process-type web`,
 	Run: createApp,
 }
 
@@ -93,16 +93,6 @@ func createApp(cmd *cobra.Command, args []string) {
 		client.PrintErrorAndExit("Invalid memory parameter")
 	}
 
-	maxCPU, err := cmd.Flags().GetString("max-cpu")
-	if err != nil {
-		client.PrintErrorAndExit("Invalid max-cpu parameter")
-	}
-
-	maxMemory, err := cmd.Flags().GetString("max-memory")
-	if err != nil {
-		client.PrintErrorAndExit("Invalid max-memory parameter")
-	}
-
 	processType, err := cmd.Flags().GetString("process-type")
 	if err != nil {
 		client.PrintErrorAndExit("Invalid process-type parameter")
@@ -118,11 +108,11 @@ func createApp(cmd *cobra.Command, args []string) {
 		Default: []*appb.CreateRequest_Limits_LimitRangeQuantity{
 			&appb.CreateRequest_Limits_LimitRangeQuantity{
 				Resource: "cpu",
-				Quantity: maxCPU,
+				Quantity: cpu,
 			},
 			&appb.CreateRequest_Limits_LimitRangeQuantity{
 				Resource: "memory",
-				Quantity: maxMemory,
+				Quantity: memory,
 			},
 		},
 		DefaultRequest: []*appb.CreateRequest_Limits_LimitRangeQuantity{
@@ -446,8 +436,6 @@ func init() {
 	appCreateCmd.Flags().Int32("scale-cpu", 70, "auto scale target cpu percentage to scale")
 	appCreateCmd.Flags().String("cpu", "200m", "allocated pod cpu")
 	appCreateCmd.Flags().String("memory", "512Mi", "allocated pod memory")
-	appCreateCmd.Flags().String("max-cpu", "500m", "when set, allows the pod to burst cpu usage up to 'max-cpu'")
-	appCreateCmd.Flags().String("max-memory", "512Mi", "when set, allows the pod to burst memory usage up to 'max-memory'")
 	appCreateCmd.Flags().String("process-type", "", "app process type")
 
 	appEnvSetCmd.Flags().String("app", "", "app name")


### PR DESCRIPTION
What do you think? Is it a good idea to remove those values from the server too?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa/284)
<!-- Reviewable:end -->
