### PR TITLE
use the cluster informed by the user to shows command advice

### DIFF
--- a/pkg/client/cmd/app.go
+++ b/pkg/client/cmd/app.go
@@ -318,9 +318,12 @@ func appEnvSet(cmd *cobra.Command, args []string) {
 		evs[i] = &appb.SetEnvRequest_EnvVar{Key: tmp[0], Value: tmp[1]}
 	}
 
-	currentClusterName, err := getCurrentClusterName()
-	if err != nil {
-		client.PrintErrorAndExit("error reading config file: %v", err)
+	currentClusterName := cfgCluster
+	if currentClusterName == "" {
+		currentClusterName, err = getCurrentClusterName()
+		if err != nil {
+			client.PrintErrorAndExit("error reading config file: %v", err)
+		}
 	}
 
 	fmt.Printf("Setting env vars and %s %s on %s...\n", color.YellowString("restarting"), color.CyanString(`"%s"`, appName), color.YellowString(`"%s"`, currentClusterName))
@@ -341,7 +344,7 @@ func appEnvSet(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	conn, err := connection.New(cfgFile, cfgCluster)
+	conn, err := connection.New(cfgFile, currentClusterName)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %s", err)
 	}
@@ -386,9 +389,12 @@ func appEnvUnset(cmd *cobra.Command, args []string) {
 		client.PrintErrorAndExit("Invalid app parameter")
 	}
 
-	currentClusterName, err := getCurrentClusterName()
-	if err != nil {
-		client.PrintErrorAndExit("error reading config file: %v", err)
+	currentClusterName := cfgCluster
+	if currentClusterName == "" {
+		currentClusterName, err = getCurrentClusterName()
+		if err != nil {
+			client.PrintErrorAndExit("error reading config file: %v", err)
+		}
 	}
 
 	fmt.Printf("Unsetting env vars and %s %s on %s...\n", color.YellowString("restarting"), color.CyanString(`"%s"`, appName), color.YellowString(`"%s"`, currentClusterName))
@@ -409,7 +415,7 @@ func appEnvUnset(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	conn, err := connection.New(cfgFile, cfgCluster)
+	conn, err := connection.New(cfgFile, currentClusterName)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %s", err)
 	}

--- a/pkg/client/cmd/deploy.go
+++ b/pkg/client/cmd/deploy.go
@@ -174,9 +174,12 @@ func deployApp(cmd *cobra.Command, args []string) {
 		client.PrintErrorAndExit("Invalid no-input parameter")
 	}
 
-	currentClusterName, err := getCurrentClusterName()
-	if err != nil {
-		client.PrintErrorAndExit("error reading config file: %v", err)
+	currentClusterName := cfgCluster
+	if currentClusterName == "" {
+		currentClusterName, err = getCurrentClusterName()
+		if err != nil {
+			client.PrintErrorAndExit("error reading config file: %v", err)
+		}
 	}
 
 	fmt.Printf("Deploying app %s to the cluster %s...\n", color.CyanString(`"%s"`, appName), color.YellowString(`"%s"`, currentClusterName))
@@ -189,7 +192,7 @@ func deployApp(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	conn, err := connection.New(cfgFile, cfgCluster)
+	conn, err := connection.New(cfgFile, currentClusterName)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}


### PR DESCRIPTION
for commands: `env-set`, `env-unset` and `deploy`.

Without those changes, the client will show a cluster name in the command message but will perform the command in another cluster, f.ex:
```shell
$ teresa app env-unset FOO --cluster production --app awesome-app
Unsetting env vars and restarting "awesome-app" on "staging"...
  FOO
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa/311)
<!-- Reviewable:end -->
