### PR TITLE
add help while running the deprecated `teresa deploy`

### DIFF
--- a/pkg/client/cmd/deploy.go
+++ b/pkg/client/cmd/deploy.go
@@ -27,6 +27,10 @@ import (
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "Everything about deploys",
+	Long: `To deploy your application you must use the new "teresa deploy create ..."
+
+To see the "deploy create" help, please enter either "teresa deploy create --help"
+or just "teresa deploy create".`,
 }
 
 var deployCreateCmd = &cobra.Command{


### PR DESCRIPTION
We've updated the deploy command to match the pattern we've been using across the whole app, which is: `entity action`.

So to inform the users of the new cli signature, I've added a tiny help text redirecting them to the new command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa/340)
<!-- Reviewable:end -->
