### PR TITLE
check --cluster flag when saving token to config file in teresa login 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Next Version] - Release Date
+### Fixed
+- login now use the --cluster flag to save the token to config file
+
 ## [0.8.0] - 2017-09-18
 ### Added
 - Command 'deploy list'

--- a/pkg/client/cmd/login_cluster.go
+++ b/pkg/client/cmd/login_cluster.go
@@ -49,7 +49,7 @@ func login(cmd *cobra.Command, args []string) {
 	}
 	color.Green("Login OK")
 
-	if err = client.SaveToken(cfgFile, res.Token); err != nil {
+	if err = client.SaveToken(cfgFile, cfgCluster, res.Token); err != nil {
 		client.PrintErrorAndExit("Error trying to save token in configuration file: %v", err)
 	}
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -38,18 +38,22 @@ func init() {
 	DefaultConfigFileLocation = filepath.Join(homeDir, ".teresa", "config.yaml")
 }
 
-func SaveToken(cfgFile, token string) error {
+func SaveToken(cfgFile, cfgCluster, token string) error {
 	cfg, err := ReadConfigFile(cfgFile)
 	if err != nil {
 		return err
 	}
-	cc, ok := cfg.Clusters[cfg.CurrentCluster]
+	cluster := cfgCluster
+	if cluster == "" {
+		cluster = cfg.CurrentCluster
+	}
+	cc, ok := cfg.Clusters[cluster]
 	if !ok {
 		return ErrInvalidConfigFile
 	}
 
 	cc.Token = token
-	cfg.Clusters[cfg.CurrentCluster] = cc
+	cfg.Clusters[cluster] = cc
 	return SaveConfigFile(cfgFile, cfg)
 }
 

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -138,7 +138,7 @@ func TestSaveTokenForInvalidConfigFile(t *testing.T) {
 	}
 	defer os.Remove(confPath)
 
-	if err := SaveToken(confPath, "gopher"); err != ErrInvalidConfigFile {
+	if err := SaveToken(confPath, "", "gopher"); err != ErrInvalidConfigFile {
 		t.Errorf("expected ErrInvalidConfigFile, got %v", err)
 	}
 }
@@ -159,7 +159,7 @@ func TestSaveToken(t *testing.T) {
 	defer os.Remove(confPath)
 
 	expectedToken := "gopher"
-	if err := SaveToken(confPath, expectedToken); err != nil {
+	if err := SaveToken(confPath, "", expectedToken); err != nil {
 		t.Fatal("error trying to save token: ", err)
 	}
 


### PR DESCRIPTION
The `teresa login` ignore the `--cluster` flag on saving token to config file, this pr fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa/348)
<!-- Reviewable:end -->
