### PR TITLE
handle hpa not found (as normal behavior) on app info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Next Version] - Release Date
 ### Fixed
 - login now use the --cluster flag to save the token to config file
+- Don't return error on `app info` command if the app doesn't have HPA
 
 ## [0.8.0] - 2017-09-18
 ### Added

--- a/pkg/server/k8s/client.go
+++ b/pkg/server/k8s/client.go
@@ -342,6 +342,9 @@ func (k *k8sClient) Autoscale(namespace string) (*app.Autoscale, error) {
 
 	hpa, err := kc.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(namespace)
 	if err != nil {
+		if k.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "get autoscale failed")
 	}
 


### PR DESCRIPTION
Others layers  (converter, handler, cli, etc) already deal with `nil` autoscale information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa/350)
<!-- Reviewable:end -->
