### PR TITLE
configurable timeout of `PodRun` process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Upgrade `slugbuilder` version to `v3.0.0`
+- Timeout of `PodRun` process (deploy and release) now is configurable
 
 ### Added
 - Allows developers to set the JWT auth token expiration period

--- a/pkg/server/k8s/client.go
+++ b/pkg/server/k8s/client.go
@@ -29,6 +29,7 @@ const (
 type k8sClient struct {
 	conf               *restclient.Config
 	defaultServiceType string
+	podRunTimeout      time.Duration
 }
 
 func (k *k8sClient) buildClient() (*kubernetes.Clientset, error) {
@@ -452,7 +453,7 @@ func (k *k8sClient) PodRun(podSpec *deploy.PodSpec) (io.ReadCloser, <-chan int, 
 		}
 		io.Copy(w, stream)
 
-		if err = k.waitPodEnd(pod, 3*time.Second, 30*time.Minute); err != nil {
+		if err = k.waitPodEnd(pod, 3*time.Second, k.podRunTimeout); err != nil {
 			return
 		}
 
@@ -716,6 +717,8 @@ func newOutOfClusterK8sClient(conf *Config) (Client, error) {
 		return nil, err
 	}
 	return &k8sClient{
-		conf: k8sConf, defaultServiceType: conf.DefaultServiceType,
+		conf:               k8sConf,
+		defaultServiceType: conf.DefaultServiceType,
+		podRunTimeout:      conf.PodRunTimeout,
 	}, nil
 }

--- a/pkg/server/k8s/k8s.go
+++ b/pkg/server/k8s/k8s.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"time"
+
 	"github.com/luizalabs/teresa/pkg/server/app"
 	"github.com/luizalabs/teresa/pkg/server/deploy"
 	"github.com/luizalabs/teresa/pkg/server/healthcheck"
@@ -14,8 +16,9 @@ var validServiceTypes = map[api.ServiceType]bool{
 }
 
 type Config struct {
-	ConfigFile         string `split_words:"true"`
-	DefaultServiceType string `split_words:"true" default:"LoadBalancer"`
+	ConfigFile         string        `split_words:"true"`
+	DefaultServiceType string        `split_words:"true" default:"LoadBalancer"`
+	PodRunTimeout      time.Duration `split_words:"true" default:"30m"`
 }
 
 type Client interface {


### PR DESCRIPTION
A bunch migrations are critical and (unfortunately) makes locks on the database. So, to prevent any dangerous behaviors, we can configure the timeout of pod run process to a large duration.