### PR TITLE
add current env to app info

### DIFF
--- a/pkg/client/cmd/app.go
+++ b/pkg/client/cmd/app.go
@@ -280,6 +280,13 @@ func appInfo(cmd *cobra.Command, args []string) {
 	color.New(color.FgCyan, color.Bold).Printf("[%s]\n", name)
 	bold := color.New(color.Bold).SprintFunc()
 
+	f, err := client.ReadConfigFile(cfgFile)
+	if err != nil {
+		client.PrintErrorAndExit("Cannot read the config file, have you created it with `teresa set-cluster` command?")
+	}
+
+	color.New(color.FgRed, color.Bold).Printf("env: %s\n", f.CurrentCluster)
+
 	fmt.Println(bold("team:"), info.Team)
 	if len(info.Addresses) > 0 {
 		fmt.Println(bold("addresses:"))


### PR DESCRIPTION
It is possible for users to manipulate an APP in the wrong environment
and to avoid that I suggest adding the current environment when listing
the APP info.

A possible downside of this change is the fact that it is using the
function `ReadConfigFile (cfgFile)) (*Config, error)` to get the current
cluster name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa/370)
<!-- Reviewable:end -->
