### PR TITLE
Fix teresaignore on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Env vars being set or unset for the app on deploy update errors
 - Typo on server pkg
 - [server] Return all deploy errors to the client
+- [client] teresaignore on Windows
 
 ## [0.11.0] - 2017-12-11
 ### Added

--- a/pkg/client/tar/tar.go
+++ b/pkg/client/tar/tar.go
@@ -2,6 +2,10 @@ package tar
 
 import "github.com/jhoonb/archivex"
 
+const (
+	PathSeparator = "/"
+)
+
 type Writer interface {
 	AddFile(string, string) error
 	AddAll(string) error


### PR DESCRIPTION
Use "/" as tar path separator as this is the portable way.