### PR TITLE
Add config to show or not gorm logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [server] default deploy lifecycle with 10s drain timeout
+- [server] configurable env (`TERESA_DB_SHOW_LOGS`) to show (or not) database logs (default `false`)
 
 ## [0.13.0] - 2018-01-22
 ### Fixed

--- a/pkg/server/database/database.go
+++ b/pkg/server/database/database.go
@@ -20,6 +20,7 @@ type Config struct {
 	Username string
 	Password string
 	Database string
+	ShowLogs bool `split_words:"true" default:"false"`
 }
 
 func New(conf *Config) (*gorm.DB, error) {
@@ -64,6 +65,6 @@ func New(conf *Config) (*gorm.DB, error) {
 		"user":    conf.Username,
 	}).Info("connected to database")
 
-	db.LogMode(true)
+	db.LogMode(conf.ShowLogs)
 	return db, nil
 }


### PR DESCRIPTION
Env `TERESA_DB_SHOW_LOGS` with default value to `false`.
The previous behaviors was, always show gorm logs