### PR TITLE
Change validation of error on namespace create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `app logs` support to filter by pod name
 - `app logs` support to print the logs of the previous pod instance
 
+### Changed
+- Better error message for invalid app name error
+
 ## [0.15.0] - 2018-02-14
 ### Changed
 - [server] using multistage build on teresa dockerfile

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -52,6 +52,7 @@ type K8sOperations interface {
 	Limits(namespace, name string) (*Limits, error)
 	IsNotFound(err error) bool
 	IsAlreadyExists(err error) bool
+	IsInvalid(err error) bool
 	SetNamespaceAnnotations(namespace string, annotations map[string]string) error
 	SetNamespaceLabels(namespace string, labels map[string]string) error
 	DeleteDeployEnvVars(namespace, name string, evNames []string) error
@@ -106,6 +107,8 @@ func (ops *AppOperations) Create(user *database.User, app *App) (Err error) {
 	if err := ops.kops.CreateNamespace(app, user.Email); err != nil {
 		if ops.kops.IsAlreadyExists(err) {
 			return ErrAlreadyExists
+		} else if ops.kops.IsInvalid(err) {
+			return ErrInvalidName
 		}
 		return teresa_errors.NewInternalServerError(err)
 	}

--- a/pkg/server/app/errors.go
+++ b/pkg/server/app/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrAlreadyExists    = status.Errorf(codes.AlreadyExists, "App already exists")
 	ErrNotFound         = status.Errorf(codes.NotFound, "App not found")
 	ErrProtectedEnvVar  = status.Errorf(codes.InvalidArgument, "Can't change protected env vars")
+	ErrInvalidName      = status.Errorf(codes.InvalidArgument, "Invalid App Name")
 	ErrInvalidLimits    = status.Errorf(codes.InvalidArgument, "Invalid Limits")
 	ErrInvalidAutoscale = status.Errorf(codes.InvalidArgument, "Invalid Autoscale")
 )

--- a/pkg/server/k8s/errors.go
+++ b/pkg/server/k8s/errors.go
@@ -23,3 +23,7 @@ func (k *Client) IsNotFound(err error) bool {
 func (k *Client) IsAlreadyExists(err error) bool {
 	return k8serrors.IsAlreadyExists(errors.Cause(err))
 }
+
+func (k *Client) IsInvalid(err error) bool {
+	return k8serrors.IsInvalid(errors.Cause(err))
+}


### PR DESCRIPTION
To return a friendly error message when an invalid app name is used
in app create method