### PR TITLE
Better error handling in app env-set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Better error message for invalid app name error
+- Better error message for invalid env var name error
 
 ## [0.15.0] - 2018-02-14
 ### Changed

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -301,7 +301,9 @@ func (ops *AppOperations) SetEnv(user *database.User, appName string, evs []*Env
 	}
 
 	if err = ops.kops.CreateOrUpdateDeployEnvVars(appName, appName, evs); err != nil {
-		if !ops.kops.IsNotFound(err) {
+		if ops.kops.IsInvalid(err) {
+			return ErrInvalidEnvVarName
+		} else if !ops.kops.IsNotFound(err) {
 			return teresa_errors.NewInternalServerError(err)
 		}
 	}

--- a/pkg/server/app/errors.go
+++ b/pkg/server/app/errors.go
@@ -6,10 +6,11 @@ import (
 )
 
 var (
-	ErrAlreadyExists    = status.Errorf(codes.AlreadyExists, "App already exists")
-	ErrNotFound         = status.Errorf(codes.NotFound, "App not found")
-	ErrProtectedEnvVar  = status.Errorf(codes.InvalidArgument, "Can't change protected env vars")
-	ErrInvalidName      = status.Errorf(codes.InvalidArgument, "Invalid App Name")
-	ErrInvalidLimits    = status.Errorf(codes.InvalidArgument, "Invalid Limits")
-	ErrInvalidAutoscale = status.Errorf(codes.InvalidArgument, "Invalid Autoscale")
+	ErrAlreadyExists     = status.Errorf(codes.AlreadyExists, "App already exists")
+	ErrNotFound          = status.Errorf(codes.NotFound, "App not found")
+	ErrProtectedEnvVar   = status.Errorf(codes.InvalidArgument, "Can't change protected env vars")
+	ErrInvalidName       = status.Errorf(codes.InvalidArgument, "Invalid App Name")
+	ErrInvalidLimits     = status.Errorf(codes.InvalidArgument, "Invalid Limits")
+	ErrInvalidAutoscale  = status.Errorf(codes.InvalidArgument, "Invalid Autoscale")
+	ErrInvalidEnvVarName = status.Errorf(codes.InvalidArgument, "Invalid Env Var Name")
 )


### PR DESCRIPTION
Return a friendly error message when the env var name is invalid.