### PR TITLE
Change command to get and install goreleaser on travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ jobs:
     - stage: build and release client
       script:
         - if [ -z "$TRAVIS_TAG" ]; then exit 0; fi
-        - go get github.com/goreleaser/goreleaser
+        - curl -sL http://git.io/goreleaser | bash
         - goreleaser --release-notes <(python release-notes.py)


### PR DESCRIPTION
Related to issue https://github.com/goreleaser/goreleaser/issues/588
and follow the [official docs](https://goreleaser.com/\#continuous_integration.travis)