### PR TITLE
Add default limit to the cronjob jobs history

### DIFF
--- a/pkg/server/k8s/converters.go
+++ b/pkg/server/k8s/converters.go
@@ -221,6 +221,8 @@ func cronJobSpecToK8sCronJob(cronJobSpec *spec.CronJob) (*k8sv2alpha.CronJob, er
 		InitContainers:               initContainers,
 	}
 
+	successfulLim := cronJobSpec.SuccessfulJobsHistoryLimit
+	failedLim := cronJobSpec.FailedJobsHistoryLimit
 	cj := &k8sv2alpha.CronJob{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "batch/v2alpha1",
@@ -244,6 +246,8 @@ func cronJobSpecToK8sCronJob(cronJobSpec *spec.CronJob) (*k8sv2alpha.CronJob, er
 					},
 				},
 			},
+			SuccessfulJobsHistoryLimit: &successfulLim,
+			FailedJobsHistoryLimit:     &failedLim,
 		},
 	}
 	return cj, nil

--- a/pkg/server/k8s/converters_test.go
+++ b/pkg/server/k8s/converters_test.go
@@ -391,7 +391,9 @@ func TestCronJobSpecToK8sCronJob(t *testing.T) {
 				}},
 			},
 		},
-		Schedule: "*/1 * * * *",
+		Schedule:                   "*/1 * * * *",
+		SuccessfulJobsHistoryLimit: 42,
+		FailedJobsHistoryLimit:     33,
 	}
 
 	k8sCron, err := cronJobSpecToK8sCronJob(cs)
@@ -420,5 +422,15 @@ func TestCronJobSpecToK8sCronJob(t *testing.T) {
 	initContainers := k8sCron.Spec.JobTemplate.Spec.Template.Spec.InitContainers
 	if len(initContainers) != len(cs.Pod.InitContainers) {
 		t.Errorf("expected %d, got %d", len(cs.Pod.InitContainers), len(initContainers))
+	}
+
+	lim := k8sCron.Spec.SuccessfulJobsHistoryLimit
+	if *lim != cs.SuccessfulJobsHistoryLimit {
+		t.Errorf("expected %d, got %d", cs.SuccessfulJobsHistoryLimit, *lim)
+	}
+
+	lim = k8sCron.Spec.FailedJobsHistoryLimit
+	if *lim != cs.FailedJobsHistoryLimit {
+		t.Errorf("expected %d, got %d", cs.FailedJobsHistoryLimit, *lim)
 	}
 }

--- a/pkg/server/spec/cronjob.go
+++ b/pkg/server/spec/cronjob.go
@@ -5,9 +5,15 @@ import (
 	"github.com/luizalabs/teresa/pkg/server/storage"
 )
 
+const (
+	defaultJobHistoryLimit = 3
+)
+
 type CronJob struct {
 	Deploy
-	Schedule string
+	Schedule                   string
+	SuccessfulJobsHistoryLimit int32
+	FailedJobsHistoryLimit     int32
 }
 
 func NewCronJob(description, slugURL, schedule string, imgs *SlugImages, a *app.App, fs storage.Storage, args ...string) *CronJob {
@@ -33,8 +39,10 @@ func NewCronJob(description, slugURL, schedule string, imgs *SlugImages, a *app.
 	}
 
 	cs := &CronJob{
-		Deploy:   ds,
-		Schedule: schedule,
+		Deploy:                     ds,
+		Schedule:                   schedule,
+		SuccessfulJobsHistoryLimit: defaultJobHistoryLimit,
+		FailedJobsHistoryLimit:     defaultJobHistoryLimit,
 	}
 
 	return cs


### PR DESCRIPTION
The default is 3 for both successful and failed jobs.