### PR TITLE
Fix cronjob creation when the schedule is missing

### DIFF
--- a/pkg/server/deploy/deploy.go
+++ b/pkg/server/deploy/deploy.go
@@ -169,6 +169,10 @@ func (ops *DeployOperations) createOrUpdateCronJob(a *app.App, confFiles *Deploy
 		Runner: ops.opts.SlugRunnerImage,
 		Store:  ops.opts.SlugStoreImage,
 	}
+	if confFiles.TeresaYaml == nil || confFiles.TeresaYaml.Cron == nil {
+		errChan <- ErrCronScheduleNotFound
+		return
+	}
 	cronSpec := spec.NewCronJob(
 		description,
 		slugURL,

--- a/pkg/server/deploy/deploy_test.go
+++ b/pkg/server/deploy/deploy_test.go
@@ -281,6 +281,30 @@ func TestCreateCronJobReturnError(t *testing.T) {
 	}
 }
 
+func TestCreateCronJobScheduleNotFound(t *testing.T) {
+	a := &app.App{Name: "test", ProcessType: app.ProcessTypeCron}
+	errChan := make(chan error, 1)
+	conf := &DeployConfigFiles{
+		Procfile:   map[string]string{"cron": "echo hello world"},
+		TeresaYaml: &spec.TeresaYaml{},
+	}
+	fakeK8s := new(fakeK8sOperations)
+	ops := NewDeployOperations(
+		app.NewFakeOperations(),
+		fakeK8s,
+		st.NewFake(),
+		exec.NewFakeOperations(),
+		&Options{},
+	)
+
+	deployOperations := ops.(*DeployOperations)
+	deployOperations.createOrUpdateCronJob(a, conf, new(bytes.Buffer), errChan, "test", "test")
+
+	if err := <-errChan; err != ErrCronScheduleNotFound {
+		t.Errorf("expected %v, got %v", ErrCronScheduleNotFound, err)
+	}
+}
+
 func TestExposeApp(t *testing.T) {
 	var testCases = []struct {
 		appProcessType                string

--- a/pkg/server/deploy/errors.go
+++ b/pkg/server/deploy/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrBuildFail             = status.Errorf(codes.Unknown, "Build returned a non zero value")
 	ErrReleaseFail           = status.Errorf(codes.Unknown, "Release command returned a non zero value")
 	ErrInvalidTeresaYamlFile = status.Errorf(codes.InvalidArgument, "Invalid Teresa Yaml file")
+	ErrCronScheduleNotFound  = status.Errorf(codes.InvalidArgument, "Cron schedule not found in teresa yaml file")
 )


### PR DESCRIPTION
We return a schedule not found message to the client.