### PR TITLE
Check if an app is a CronJob by `cron` prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Default max-cpu app limit to 400m
 - [HELM] Bump minio version to v0.5.5
 - [server] Change the pull policy to always pull
+- Infer if an app is a cronjob by `cron` prefix on process type
 
 ### Added
 - Support Nginx as sidecar

--- a/README.md
+++ b/README.md
@@ -218,11 +218,10 @@ Filter the logs by container name:
 
 **Q: How to create a CronJob?**
 
+Teresa will infer if an app is a cronjob by checking if the prefix of _process-type_
+is `cron` (e.g. `cron`, `cronjob`, `cron-method-a`).
+
     $ teresa app create <app-name> --team <team-name> --process-type cron
-
-Make sure to have the `cron` key with the cronjob command.
-
-**Q: How to define the schedule of the CronJob?**
 
 You can define the schedule of cron by adding this lines to `teresa.yaml`:
 
@@ -230,6 +229,8 @@ You can define the schedule of cron by adding this lines to `teresa.yaml`:
 cron:
   schedule: "*/30 * * * *"
 ```
+
+Make sure to have the related (i.e. same value of the process-type) key with the cronjob command on the `Procfile`.
 
 ### Development
 

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -128,7 +128,7 @@ func (ops *AppOperations) Create(user *database.User, app *App) (Err error) {
 		return teresa_errors.NewInternalServerError(err)
 	}
 
-	if app.ProcessType == ProcessTypeCron {
+	if IsCronJob(app.ProcessType) {
 		return nil
 	}
 
@@ -319,7 +319,7 @@ func (ops *AppOperations) SetEnv(user *database.User, appName string, evs []*Env
 		return err
 	}
 
-	if app.ProcessType == ProcessTypeCron {
+	if IsCronJob(app.ProcessType) {
 		err = ops.kops.CreateOrUpdateCronJobEnvVars(appName, appName, evs)
 	} else {
 		err = ops.kops.CreateOrUpdateDeployEnvVars(appName, appName, evs)
@@ -352,7 +352,7 @@ func (ops *AppOperations) UnsetEnv(user *database.User, appName string, evNames 
 		return err
 	}
 
-	if app.ProcessType == ProcessTypeCron {
+	if IsCronJob(app.ProcessType) {
 		err = ops.kops.DeleteCronJobEnvVars(appName, appName, evNames)
 	} else {
 		err = ops.kops.DeleteDeployEnvVars(appName, appName, evNames)
@@ -425,7 +425,7 @@ func (ops *AppOperations) SetSecret(user *database.User, appName string, secrets
 		return teresa_errors.NewInternalServerError(err)
 	}
 
-	if app.ProcessType == ProcessTypeCron {
+	if IsCronJob(app.ProcessType) {
 		err = ops.kops.CreateOrUpdateCronJobSecretEnvVars(appName, appName, TeresaAppSecrets, names)
 	} else {
 		err = ops.kops.CreateOrUpdateDeploySecretEnvVars(appName, appName, TeresaAppSecrets, names)
@@ -479,7 +479,7 @@ func (ops *AppOperations) UnsetSecret(user *database.User, appName string, secre
 		return teresa_errors.NewInternalServerError(err)
 	}
 
-	if app.ProcessType == ProcessTypeCron {
+	if IsCronJob(app.ProcessType) {
 		err = ops.kops.DeleteCronJobEnvVars(appName, appName, secrets)
 	} else {
 		err = ops.kops.DeleteDeployEnvVars(appName, appName, secrets)
@@ -547,7 +547,7 @@ func (ops *AppOperations) SetAutoscale(user *database.User, appName string, as *
 		return err
 	}
 
-	if app.ProcessType == ProcessTypeCron {
+	if IsCronJob(app.ProcessType) {
 		return ErrInvalidActionForCronJob
 	}
 
@@ -591,7 +591,7 @@ func (ops *AppOperations) SetReplicas(user *database.User, appName string, repli
 		return err
 	}
 
-	if app.ProcessType == ProcessTypeCron {
+	if IsCronJob(app.ProcessType) {
 		return ErrInvalidActionForCronJob
 	}
 

--- a/pkg/server/app/app_test.go
+++ b/pkg/server/app/app_test.go
@@ -348,13 +348,14 @@ func TestAppOperationsCreate(t *testing.T) {
 }
 
 func TestAppOperationsCreateCronDoesNotCreateHPA(t *testing.T) {
+	validCronPt := fmt.Sprintf("%s-test", ProcessTypeCronPrefix)
 	tops := team.NewFakeOperations()
 	fakeSt := st.NewFake()
 	fakeK8s := &fakeK8sOperations{}
 	ops := NewOperations(tops, &fakeK8sOperations{}, fakeSt)
 	name := "luizalabs"
 	user := &database.User{Email: "teresa@luizalabs.com"}
-	app := &App{Name: "teresa", Team: name, ProcessType: ProcessTypeCron}
+	app := &App{Name: "teresa", Team: name, ProcessType: validCronPt}
 	tops.(*team.FakeOperations).Storage[name] = &database.Team{
 		Name:  name,
 		Users: []database.User{*user},
@@ -895,8 +896,9 @@ func TestAppOpsSetEnvErrInvalidEnvVarName(t *testing.T) {
 }
 
 func TestAppOperationsSetEnvForACronJob(t *testing.T) {
+	validCronPt := fmt.Sprintf("%s-test", ProcessTypeCronPrefix)
 	tops := team.NewFakeOperations()
-	fakeK8s := &fakeK8sOperations{DefaultProcessType: ProcessTypeCron}
+	fakeK8s := &fakeK8sOperations{DefaultProcessType: validCronPt}
 	ops := NewOperations(tops, fakeK8s, nil)
 	user := &database.User{Email: "teresa@luizalabs.com"}
 	app := &App{Name: "teresa", Team: "luizalabs"}
@@ -1004,8 +1006,9 @@ func TestAppOperationsUnsetEnvErrInternalServerErrorOnSaveApp(t *testing.T) {
 }
 
 func TestAppOperationsUnsetEnvForACronJob(t *testing.T) {
+	validCronPt := fmt.Sprintf("%s-test", ProcessTypeCronPrefix)
 	tops := team.NewFakeOperations()
-	fakeK8s := &fakeK8sOperations{DefaultProcessType: ProcessTypeCron}
+	fakeK8s := &fakeK8sOperations{DefaultProcessType: validCronPt}
 	ops := NewOperations(tops, fakeK8s, nil)
 	user := &database.User{Email: "teresa@luizalabs.com"}
 	app := &App{Name: "teresa", Team: "luizalabs"}
@@ -1167,10 +1170,11 @@ func TestAppOperationsSetAutoscale(t *testing.T) {
 }
 
 func TestAppOperationsSetAutoscaleInvalidActionForCronJob(t *testing.T) {
+	validCronPt := fmt.Sprintf("%s-test", ProcessTypeCronPrefix)
 	tops := team.NewFakeOperations()
-	ops := NewOperations(tops, &fakeK8sOperations{DefaultProcessType: ProcessTypeCron}, nil)
+	ops := NewOperations(tops, &fakeK8sOperations{DefaultProcessType: validCronPt}, nil)
 	user := &database.User{Email: "teresa@luizalabs.com"}
-	app := &App{Name: "teresa", Team: "luizalabs", ProcessType: ProcessTypeCron}
+	app := &App{Name: "teresa", Team: "luizalabs"}
 	tops.(*team.FakeOperations).Storage[app.Team] = &database.Team{
 		Name:  app.Team,
 		Users: []database.User{*user},
@@ -1289,10 +1293,11 @@ func TestAppOperationsSetReplicas(t *testing.T) {
 }
 
 func TestAppOperationsSetReplicasInvalidForCronJob(t *testing.T) {
+	validCronPt := fmt.Sprintf("%s-test", ProcessTypeCronPrefix)
 	tops := team.NewFakeOperations()
-	ops := NewOperations(tops, &fakeK8sOperations{DefaultProcessType: ProcessTypeCron}, nil)
+	ops := NewOperations(tops, &fakeK8sOperations{DefaultProcessType: validCronPt}, nil)
 	user := &database.User{Email: "teresa@luizalabs.com"}
-	app := &App{Name: "teresa", Team: "luizalabs", ProcessType: ProcessTypeCron}
+	app := &App{Name: "teresa", Team: "luizalabs"}
 	tops.(*team.FakeOperations).Storage[app.Team] = &database.Team{
 		Name:  app.Team,
 		Users: []database.User{*user},

--- a/pkg/server/app/cronjob.go
+++ b/pkg/server/app/cronjob.go
@@ -1,0 +1,7 @@
+package app
+
+import "strings"
+
+func IsCronJob(processType string) bool {
+	return strings.HasPrefix(processType, ProcessTypeCronPrefix)
+}

--- a/pkg/server/app/cronjob_test.go
+++ b/pkg/server/app/cronjob_test.go
@@ -1,0 +1,23 @@
+package app
+
+import "testing"
+
+func TestIsCronJob(t *testing.T) {
+	var testCases = []struct {
+		processType string
+		expected    bool
+	}{
+		{"cron", true},
+		{"cron-nro1", true},
+		{"cronjob", true},
+		{"web", false},
+		{"worker", false},
+		{"beat", false},
+	}
+
+	for _, tc := range testCases {
+		if actual := IsCronJob(tc.processType); actual != tc.expected {
+			t.Errorf("expected %v, got %v [case: %s]", tc.expected, actual, tc.processType)
+		}
+	}
+}

--- a/pkg/server/app/models.go
+++ b/pkg/server/app/models.go
@@ -3,8 +3,8 @@ package app
 import appb "github.com/luizalabs/teresa/pkg/protobuf/app"
 
 const (
-	ProcessTypeWeb  = "web"
-	ProcessTypeCron = "cron"
+	ProcessTypeWeb        = "web"
+	ProcessTypeCronPrefix = "cron"
 )
 
 type LimitRangeQuantity struct {

--- a/pkg/server/deploy/deploy.go
+++ b/pkg/server/deploy/deploy.go
@@ -86,7 +86,7 @@ func (ops *DeployOperations) Deploy(ctx context.Context, user *database.User, ap
 		}
 
 		slugURL := fmt.Sprintf("%s/slug.tgz", buildDest)
-		if a.ProcessType == app.ProcessTypeCron {
+		if app.IsCronJob(a.ProcessType) {
 			ops.createOrUpdateCronJob(a, confFiles, w, errChan, slugURL, description)
 		} else {
 			ops.createOrUpdateDeploy(a, confFiles, w, errChan, slugURL, description, deployId)
@@ -192,7 +192,7 @@ func (ops *DeployOperations) createOrUpdateCronJob(a *app.App, confFiles *Deploy
 		imgs,
 		a,
 		ops.fileStorage,
-		strings.Split(confFiles.Procfile[app.ProcessTypeCron], " ")...,
+		strings.Split(confFiles.Procfile[a.ProcessType], " ")...,
 	)
 
 	if err := ops.k8s.CreateOrUpdateCronJob(cronSpec); err != nil {

--- a/pkg/server/deploy/deploy_test.go
+++ b/pkg/server/deploy/deploy_test.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -208,13 +209,14 @@ func TestCreateDeployReturnError(t *testing.T) {
 }
 
 func TestCreateCronJob(t *testing.T) {
+	validCronPt := fmt.Sprintf("%s-hw", app.ProcessTypeCronPrefix)
 	expectedName := "Test cron"
-	a := &app.App{Name: expectedName, ProcessType: app.ProcessTypeCron}
+	a := &app.App{Name: expectedName, ProcessType: validCronPt}
 	expectedDescription := "test-description"
 	expectedSlugURL := "test-slug"
 	errChan := make(chan error, 1)
 	conf := &DeployConfigFiles{
-		Procfile: map[string]string{"cron": "echo hello world"},
+		Procfile: map[string]string{validCronPt: "echo hello world"},
 		TeresaYaml: &spec.TeresaYaml{
 			Cron: &spec.CronArgs{Schedule: "*/1 * * * *"},
 		},
@@ -288,10 +290,11 @@ func TestCreateCronJobReturnError(t *testing.T) {
 }
 
 func TestCreateCronJobScheduleNotFound(t *testing.T) {
-	a := &app.App{Name: "test", ProcessType: app.ProcessTypeCron}
+	validCronPt := fmt.Sprintf("%s-hw", app.ProcessTypeCronPrefix)
+	a := &app.App{Name: "test", ProcessType: validCronPt}
 	errChan := make(chan error, 1)
 	conf := &DeployConfigFiles{
-		Procfile:   map[string]string{"cron": "echo hello world"},
+		Procfile:   map[string]string{validCronPt: "echo hello world"},
 		TeresaYaml: &spec.TeresaYaml{},
 	}
 	fakeK8s := new(fakeK8sOperations)


### PR DESCRIPTION
This change allows users to create more than one cron job per code base
(ex. `cron`, `cron-a`, `cronjob`, `cron-b`, etc)