### PR TITLE
Protect nginx vars from being interpreted as env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - `.teresaignore` behavior (to work like `.gitignore`)
+- Protect nginx vars from being interpreted as env vars
 
 ## [0.17.0] - 2018-03-20
 ### Changed

--- a/pkg/server/spec/container_test.go
+++ b/pkg/server/spec/container_test.go
@@ -1,0 +1,25 @@
+package spec
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewNginxContainerArgs(t *testing.T) {
+	env := map[string]string{"key1": "value1", "key2": "value2"}
+	keys := "$key1 $key2"
+	want := fmt.Sprintf(
+		nginxArgTmpl,
+		keys,
+		nginxConfTmplDir,
+		nginxConfFile,
+		nginxConfDir,
+		nginxConfFile,
+	)
+
+	got := newNginxContainerArgs(env)
+
+	if got != want {
+		t.Errorf("got %s; want %s", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #465.