### PR TITLE
Return `ErrTimeout` on pod run when `wait.PollImmediate` return timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [NEXT_RELEASE]
+### Fixed
+- Return error with timeout message when there's no resources for build, release phase and command exec
+
 ## [0.18.0] - 2018-03-27
 ### Added
 - `service` command, for now only used to enable ssl support

--- a/pkg/server/deploy/deploy.go
+++ b/pkg/server/deploy/deploy.go
@@ -246,6 +246,9 @@ func (ops *DeployOperations) podRun(ctx context.Context, podSpec *spec.Pod, stre
 	go io.Copy(stream, podStream)
 
 	if err := <-runErrChan; err != nil {
+		if err == exec.ErrTimeout {
+			return err
+		}
 		return ErrPodRunFail
 	}
 

--- a/pkg/server/deploy/deploy_test.go
+++ b/pkg/server/deploy/deploy_test.go
@@ -355,7 +355,9 @@ func TestBuildApp(t *testing.T) {
 		commandErr  error
 		expectedErr error
 	}{
-		{nil, nil}, {exec.ErrNonZeroExitCode, ErrBuildFail},
+		{nil, nil},
+		{exec.ErrNonZeroExitCode, ErrBuildFail},
+		{exec.ErrTimeout, exec.ErrTimeout},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/server/exec/errors.go
+++ b/pkg/server/exec/errors.go
@@ -8,4 +8,5 @@ import (
 var (
 	ErrDeployNotFound  = status.Errorf(codes.NotFound, "Current deploy not found")
 	ErrNonZeroExitCode = status.Errorf(codes.Unknown, "Exec command returned a non zero value")
+	ErrTimeout         = status.Errorf(codes.Aborted, "Timeout on performing the command")
 )

--- a/pkg/server/exec/exec_test.go
+++ b/pkg/server/exec/exec_test.go
@@ -98,7 +98,7 @@ func TestOpsRunCommandBySpec(t *testing.T) {
 }
 
 func TestRunCommandBySpecNoZeroExitCode(t *testing.T) {
-	k8sOps := &fakeK8sOperations{exitCodePodRun: 1}
+	k8sOps := &fakeK8sOperations{exitCodePodRun: ExitCodeError}
 	ops := NewOperations(app.NewFakeOperations(), k8sOps, storage.NewFake(), &Defaults{})
 
 	rc, errChan := ops.RunCommandBySpec(context.Background(), &spec.Pod{})
@@ -106,6 +106,18 @@ func TestRunCommandBySpecNoZeroExitCode(t *testing.T) {
 
 	if err := <-errChan; err != ErrNonZeroExitCode {
 		t.Errorf("expected ErrNonZeroExitCode, got %v", err)
+	}
+}
+
+func TestRunCommandBySpecTimeoutExitCode(t *testing.T) {
+	k8sOps := &fakeK8sOperations{exitCodePodRun: ExitCodeTimeout}
+	ops := NewOperations(app.NewFakeOperations(), k8sOps, storage.NewFake(), &Defaults{})
+
+	rc, errChan := ops.RunCommandBySpec(context.Background(), &spec.Pod{})
+	defer rc.Close()
+
+	if err := <-errChan; err != ErrTimeout {
+		t.Errorf("expected ErrTimeout, got %v", err)
 	}
 }
 


### PR DESCRIPTION
This change prevents to successfully deploy message when waiting
time reach the timeout of wait of PodRun func

Fixes #464