### PR TITLE
Fix nginx cmd args tests on spec pkg

### DIFF
--- a/pkg/server/spec/container.go
+++ b/pkg/server/spec/container.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -120,6 +121,8 @@ func newNginxContainerArgs(env map[string]string) string {
 		tmp[i] = fmt.Sprintf("$%s", key)
 		i++
 	}
+	sort.Strings(tmp)
+
 	args := fmt.Sprintf(
 		nginxArgTmpl,
 		strings.Join(tmp, " "),

--- a/pkg/server/spec/container_test.go
+++ b/pkg/server/spec/container_test.go
@@ -18,7 +18,6 @@ func TestNewNginxContainerArgs(t *testing.T) {
 	)
 
 	got := newNginxContainerArgs(env)
-
 	if got != want {
 		t.Errorf("got %s; want %s", got, want)
 	}


### PR DESCRIPTION
The func and the test uses maps and we cannot guarantee the order of envs