### PR TITLE
Add server_tokens off param to nginx default conf

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -237,6 +237,8 @@ http{
         proxy_set_header HOST $host;
         proxy_pass $NGINX_BACKEND;
     }
+    
+    server_tokens off;
   }
 }
 ```


### PR DESCRIPTION
This parameter will hide the nginx version from showing when any status code page from nginx is shown. 

Many ways of hacking nginx are based in just searching by nginx and the version and this would make more difficult to hack it.