### PR TITLE
Add explicit selector to the deploy spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [NEXT_RELEASE]
 ### Changed
 - [server] Update client-go to v6.0.0 and bump minimum k8s version to 1.9
+- [server] Use an explicit selector for the deploy spec
 
 ## [0.21.0] - 2018-05-02
 ### Changed

--- a/pkg/server/k8s/converters.go
+++ b/pkg/server/k8s/converters.go
@@ -218,6 +218,9 @@ func deploySpecToK8sDeploy(deploySpec *spec.Deploy, replicas int32) (*v1beta2.De
 				Spec: ps,
 			},
 			RevisionHistoryLimit: &rhl,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: deploySpec.MatchLabels,
+			},
 		},
 	}
 	return d, nil

--- a/pkg/server/spec/deploy.go
+++ b/pkg/server/spec/deploy.go
@@ -59,6 +59,7 @@ type Deploy struct {
 	RevisionHistoryLimit int
 	Description          string
 	SlugURL              string
+	MatchLabels          Labels
 }
 
 type Images struct {
@@ -98,6 +99,7 @@ func NewDeploy(imgs *Images, description, slugURL string, rhl int, a *app.App, t
 		SlugURL:              slugURL,
 		Pod:                  *ps,
 		RevisionHistoryLimit: rhl,
+		MatchLabels:          Labels{"run": a.Name},
 	}
 
 	if tYaml != nil {


### PR DESCRIPTION
Required for new versions of kubernetes and client-go.