### PR TITLE
Add rm-cluster command to remove a cluster config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [NEXT_RELEASE]
+### Added
+- [client] Add support to remoVe remove cluster from configuration file
+
 ### Changed
 - [server] Update client-go to v6.0.0 and bump minimum k8s version to 1.9
 - [server] Use an explicit selector for the deploy spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [NEXT_RELEASE]
 ### Added
-- [client] Add support to remoVe remove cluster from configuration file
+- [client] Add support to remove remote cluster from configuration file
 
 ### Changed
 - [server] Update client-go to v6.0.0 and bump minimum k8s version to 1.9

--- a/pkg/client/cmd/config.go
+++ b/pkg/client/cmd/config.go
@@ -61,6 +61,18 @@ eg.:
 	Run: setCluster,
 }
 
+var rmClusterCmd = &cobra.Command{
+	Use:   "rm-cluster name",
+	Short: "removes a cluster entry from the config file",
+	Long: `Remove a cluster entry.
+
+eg.:
+
+  $ teresa config rm-cluster aws_staging
+	`,
+	Run: rmCluster,
+}
+
 var useClusterCmd = &cobra.Command{
 	Use:   "use-cluster name",
 	Short: "sets a cluster as the current in the config file",
@@ -86,6 +98,7 @@ func init() {
 	configCmd.AddCommand(setClusterCmd)
 
 	configCmd.AddCommand(useClusterCmd)
+	configCmd.AddCommand(rmClusterCmd)
 }
 
 func useCluster(cmd *cobra.Command, args []string) {
@@ -156,6 +169,31 @@ func setCluster(cmd *cobra.Command, args []string) {
 
 	if err = client.SaveConfigFile(cfgFile, c); err != nil {
 		client.PrintErrorAndExit("Erro trying to save config file: %v", err)
+	}
+}
+
+// rmCluster removes a server from the config file
+func rmCluster(cmd *cobra.Command, args []string) {
+	if len(args) == 0 || args[0] == "" {
+		cmd.Usage()
+		return
+	}
+
+	name := args[0]
+
+	c, err := client.ReadConfigFile(cfgFile)
+	if err != nil {
+		client.PrintErrorAndExit("Error trying to read config file: %v", err)
+	}
+
+	if _, found := c.Clusters[name]; found {
+		delete(c.Clusters, name)
+		if err = client.SaveConfigFile(cfgFile, c); err != nil {
+			client.PrintErrorAndExit("Error trying to save config file: %v", err)
+		}
+		fmt.Printf("Config %s removed\n", name)
+	} else {
+		client.PrintErrorAndExit("Config %s not found", name)
 	}
 }
 


### PR DESCRIPTION
The `rm-cluster` command receives the cluster name as the parameter, removes
it from the map variable and rewrites the config file with the remaining
clusters.

Closing #504 