### PR TITLE
Fix long running exec commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [server] Fix cloud provider detection on gce
 - [server] Save last user of deploy
+- [server] Fix long running exec commands
 
 ## [0.22.0] - 2018-06-07
 ### Changed

--- a/pkg/server/exec/handlers_test.go
+++ b/pkg/server/exec/handlers_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"testing"
+	"time"
 
 	context "golang.org/x/net/context"
 
@@ -19,7 +20,7 @@ func (sw *streamWrapper) Context() context.Context {
 }
 
 func TestCommand(t *testing.T) {
-	s := NewService(NewFakeOperations())
+	s := NewService(NewFakeOperations(), 1*time.Minute)
 
 	user := &database.User{}
 	ctx := context.WithValue(context.Background(), "user", user)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -127,7 +127,7 @@ func registerServices(s *grpc.Server, opt Options, uOps user.Operations) error {
 		LimitsMemory: opt.DeployOpt.BuildLimitMemory,
 	}
 	execOps := exec.NewOperations(appOps, opt.K8s, opt.Storage, execDefaults)
-	e := exec.NewService(execOps)
+	e := exec.NewService(execOps, opt.DeployOpt.KeepAliveTimeout)
 	e.RegisterService(s)
 
 	buildOpts := &build.Options{


### PR DESCRIPTION
Use a keepalive message. A little copying is better than the wrong
abstraction.