### PR TITLE
Always use service type LoadBalancer on builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [client] Print app name and current cluster on command `app delete`
 - [server] Set default backoff limit to 3 on cronjobs
+- [server] Always use service type LoadBalancer on builds
 
 ### Fixed
 - [server] Fix cloud provider detection on gce

--- a/pkg/server/build/build.go
+++ b/pkg/server/build/build.go
@@ -27,12 +27,11 @@ type K8sOperations interface {
 }
 
 type Options struct {
-	SlugBuilderImage   string
-	SlugRunnerImage    string
-	SlugStoreImage     string
-	BuildLimitCPU      string
-	BuildLimitMemory   string
-	DefaultServiceType string
+	SlugBuilderImage string
+	SlugRunnerImage  string
+	SlugStoreImage   string
+	BuildLimitCPU    string
+	BuildLimitMemory string
 }
 
 type BuildOperations struct {
@@ -174,7 +173,7 @@ func (ops *BuildOperations) createService(appName, buildName string, labels map[
 	svcSpec := spec.NewService(
 		appName,
 		buildName,
-		ops.opts.DefaultServiceType,
+		"LoadBalancer",
 		[]spec.ServicePort{*spec.NewDefaultServicePort("")},
 		labels,
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -131,12 +131,11 @@ func registerServices(s *grpc.Server, opt Options, uOps user.Operations) error {
 	e.RegisterService(s)
 
 	buildOpts := &build.Options{
-		SlugBuilderImage:   opt.DeployOpt.SlugBuilderImage,
-		SlugRunnerImage:    opt.DeployOpt.SlugRunnerImage,
-		SlugStoreImage:     opt.DeployOpt.SlugStoreImage,
-		BuildLimitCPU:      opt.DeployOpt.BuildLimitCPU,
-		BuildLimitMemory:   opt.DeployOpt.BuildLimitMemory,
-		DefaultServiceType: opt.DeployOpt.DefaultServiceType,
+		SlugBuilderImage: opt.DeployOpt.SlugBuilderImage,
+		SlugRunnerImage:  opt.DeployOpt.SlugRunnerImage,
+		SlugStoreImage:   opt.DeployOpt.SlugStoreImage,
+		BuildLimitCPU:    opt.DeployOpt.BuildLimitCPU,
+		BuildLimitMemory: opt.DeployOpt.BuildLimitMemory,
 	}
 	bOps := build.NewBuildOperations(opt.Storage, appOps, execOps, opt.K8s, buildOpts)
 	b := build.NewService(bOps, opt.DeployOpt.KeepAliveTimeout)


### PR DESCRIPTION
So the user can test the app even on clusters that use CLusterIP as
default.