### PR TITLE
[Proposal] Improve connection error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [server] Fix panic when monitoring the rolling update
 - [server] `app info` command output
 
+### Changed
+- [client] Print more friendly error message when connection fails
+
 ## [0.23.0] - 2018-06-21
 ### Added
 - [client] Support to remove remote cluster from configuration file

--- a/pkg/client/cmd/app.go
+++ b/pkg/client/cmd/app.go
@@ -300,7 +300,7 @@ func appInfo(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, cfgCluster)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %v", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -444,7 +444,7 @@ func appEnvSet(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, currentClusterName)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -519,7 +519,7 @@ func appEnvUnset(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, currentClusterName)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -565,7 +565,7 @@ func appSecretSet(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, currentClusterName)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -611,7 +611,7 @@ func appSecretUnset(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, currentClusterName)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -693,7 +693,7 @@ func appAutoscaleSet(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, cfgCluster)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -755,7 +755,7 @@ func appStart(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, cfgCluster)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -790,7 +790,7 @@ func appStop(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, cfgCluster)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 

--- a/pkg/client/cmd/exec.go
+++ b/pkg/client/cmd/exec.go
@@ -32,7 +32,7 @@ func execCommand(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, cfgCluster)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 

--- a/pkg/client/cmd/service.go
+++ b/pkg/client/cmd/service.go
@@ -78,7 +78,7 @@ func serviceEnableSSL(cmd *cobra.Command, args []string) {
 
 	conn, err := connection.New(cfgFile, cfgCluster)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 
@@ -153,7 +153,7 @@ func serviceWhitelistSourceRanges(cmd *cobra.Command, args []string) {
 	appName, ranges := args[0], args[1:]
 	conn, err := connection.New(cfgFile, cfgCluster)
 	if err != nil {
-		client.PrintErrorAndExit("Error connecting to server: %s", err)
+		client.PrintConnectionErrorAndExit(err)
 	}
 	defer conn.Close()
 	cli := svcpb.NewServiceClient(conn)

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -21,3 +21,11 @@ func PrintErrorAndExit(format string, args ...interface{}) {
 	fmt.Fprintln(os.Stderr, color.RedString(format, args...))
 	os.Exit(1)
 }
+
+func PrintConnectionErrorAndExit(err error) {
+	PrintErrorAndExit(
+		"A connection error occoured.\n" +
+		"Please, try again.\n\n" +
+		"Server details: %s", GetErrorMsg(err),
+	)
+}

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -44,3 +44,19 @@ func TestPrintErrorAndExit(t *testing.T) {
 	}
 	t.Errorf("expected exit status 1, got err %v", err)
 }
+
+func TestPrintConnectionErrorAndExit(t *testing.T) {
+	if os.Getenv("PRINT_CONNECTION_ERROR_AND_EXIT") == "1" {
+		PrintConnectionErrorAndExit(
+			status.Errorf(codes.Unavailable, "Server Unavailable"),
+		)
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestPrintConnectionErrorAndExit")
+	cmd.Env = append(os.Environ(), "PRINT_CONNECTION_ERROR_AND_EXIT=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("expected exit status 1, got err %v", err)
+}


### PR DESCRIPTION
Since teresa-client user don't need to know how things works, i think that a better error message can help then in day-by-day usage.

Some examples of why i think that can be useful:
- A better message, with explicit instructions to retry **can** save some time.
- A message that have the error, not the cluster configuration, can be helpful to find some real problem.


Here has my proposal changes in use. This was a try to get app info when has no connection to cluster:

**before:**
```
$ teresa app info myapp
Error connecting to server: cluster.address.youalreadyknow:666
```

**after:**
```
$ ./teresa app info myapp
A connection error occour before you command run.
Please, try again.

Error details: context deadline exceeded
```