### PR TITLE
Fix `app info` command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - [server] Fix panic when monitoring the rolling update
+- [server] `app info` command output
 
 ## [0.23.0] - 2018-06-21
 ### Added

--- a/pkg/server/k8s/client.go
+++ b/pkg/server/k8s/client.go
@@ -117,29 +117,9 @@ func (k *Client) PodList(namespace string, opts *app.PodListOptions) ([]*app.Pod
 		return nil, err
 	}
 
-	pods := make([]*app.Pod, 0)
-	for _, pod := range podList.Items {
-		p := &app.Pod{Name: pod.Name}
-
-		if pod.Status.StartTime != nil {
-			p.Age = int64(time.Since(pod.Status.StartTime.Time))
-		}
-
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Waiting != nil {
-				p.State = status.State.Waiting.Reason
-			} else if status.State.Terminated != nil {
-				p.State = status.State.Terminated.Reason
-			} else if status.State.Running != nil {
-				p.State = string(k8sv1.PodRunning)
-			}
-			p.Restarts = status.RestartCount
-			p.Ready = status.Ready
-			if p.State != "" {
-				break
-			}
-		}
-		pods = append(pods, p)
+	pods := make([]*app.Pod, len(podList.Items))
+	for i, pod := range podList.Items {
+		pods[i] = k8sPodToAppPod(&pod)
 	}
 	return pods, nil
 }


### PR DESCRIPTION
Adapt the kubectl code to get the state, restarts and ready fields
correctly. Fixes #531.