### PR TITLE
Add cluster autoscaler support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [NEXT_RELEASE]
+### Added
+- [server] Cluster autocaler support
+
 ## [0.24.1] - 2018-07-11
 ### Fixed
 - [server] Channel leak on watch deploy rolling update and service creation

--- a/pkg/server/k8s/converters.go
+++ b/pkg/server/k8s/converters.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	changeCauseAnnotation = "kubernetes.io/change-cause"
-	appTypeAnnotation     = "teresa.io/app-type"
+	changeCauseAnnotation       = "kubernetes.io/change-cause"
+	appTypeAnnotation           = "teresa.io/app-type"
+	clusterAutoscalerAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )
 
 var defaultCronjobBackofflimit = int32(3)
@@ -217,6 +218,9 @@ func deploySpecToK8sDeploy(deploySpec *spec.Deploy, replicas int32) (*v1beta2.De
 			Template: k8sv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: deploySpec.Labels,
+					Annotations: map[string]string{
+						clusterAutoscalerAnnotation: "true",
+					},
 				},
 				Spec: ps,
 			},

--- a/pkg/server/k8s/converters_test.go
+++ b/pkg/server/k8s/converters_test.go
@@ -692,3 +692,20 @@ func TestK8sPodToAppPodTerminating(t *testing.T) {
 		t.Errorf("want %v; got %v", want, pod)
 	}
 }
+
+func TestDeploySpecPodTemplateAnnotations(t *testing.T) {
+	ds := &spec.Deploy{}
+	want := map[string]string{
+		clusterAutoscalerAnnotation: "true",
+	}
+
+	k8sDeploy, err := deploySpecToK8sDeploy(ds, 1)
+	if err != nil {
+		t.Fatal("got unexpected error:", err)
+	}
+	got := k8sDeploy.Spec.Template.ObjectMeta.Annotations
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}


### PR DESCRIPTION
Add the annotation cluster-autoscaler.kubernetes.io/safe-to-evict=true,
which is necessary for pods with local storage.