### PR TITLE
Fix database initial migration on mysql 5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [server] Cluster autocaler support
 
+### Fixed
+- [server] Database initial migration on mysql 5.7
+
 ## [0.24.1] - 2018-07-11
 ### Fixed
 - [server] Channel leak on watch deploy rolling update and service creation

--- a/pkg/server/database/models.go
+++ b/pkg/server/database/models.go
@@ -9,9 +9,9 @@ import (
 
 // BaseModel declares base fields that are to be used on all models
 type BaseModel struct {
-	ID        uint      `gorm:"primary_key;"`
-	CreatedAt time.Time `gorm:"not null;"`
-	UpdatedAt time.Time `gorm:"not null;"`
+	ID        uint `gorm:"primary_key;"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // Team represents a team of developers


### PR DESCRIPTION
Remove defaults from the base model, it turns out that gorm handles the
fields CreatedAt and UpdatedAt automatically by convention.