### PR TITLE
Add Ubuntu installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ Run the following in your command-line:
 $ brew tap luizalabs/teresa-cli
 $ brew install teresa
 ```
+
+## Installing Teresa Client:
+ - UBUNTU: execute [this script](./install/install-ubuntu.sh) in the local machine.

--- a/install/install-ubuntu.sh
+++ b/install/install-ubuntu.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Installing dependencies
+echo "[ DEPENDENCIES CHECK ]"
+if [[ $(dpkg -s curl | grep -Po '(?<=Status: )[^$]*') != "install ok installed" ]]; then
+    echo " - installing dependency: 'curl'"
+    sudo apt-get install curl
+else
+    echo " - dependency 'curl' already installed"
+fi
+
+# Getting latest release download URI
+
+echo "[ LATEST DOWNLOAD URI CHECK ]"
+LATEST_URI=https://github.com/luizalabs/teresa/releases/latest/
+LATEST_VERSION=$(curl $LATEST_URI -s -L -I -o /dev/null -w '%{url_effective}' | grep -Po '(?<=tag\/)[^$]*')
+DOWNLOAD_URI=https://github.com/luizalabs/teresa/releases/download/$LATEST_VERSION/teresa-linux-amd64
+echo " - download URI: '$DOWNLOAD_URI'"
+
+# Downloading and Installing
+echo "[ DOWNLOADING & INSTALLING ]"
+echo " - downloading"
+sudo wget $DOWNLOAD_URI -xO /opt/teresa/teresa -q
+sudo chmod +x /opt/teresa/teresa
+echo " - checking 'teresa'"
+
+if [[ $(stat -c "%a" /opt/teresa/teresa) == 755 ]]; then
+    echo "   - status: OK"
+else
+    echo "   - status: ERROR"
+fi
+
+if [[ -z $(cat ~/.bashrc | grep "export PATH=$PATH:/opt/teresa/") ]]; then
+    echo " - inserting command to '.bashrc'"
+    # Only if the command isn't written into .bashrc
+    echo "# Enable 'teresa' command" >> ~/.bashrc
+    echo "export PATH=$PATH:/opt/teresa/" >> ~/.bashrc
+else:
+    echo " - command already inserted to '.bashrc'"
+fi;
+
+echo " - enabling 'teresa' command"
+source ~/.bashrc
+echo "[ DONE ]"


### PR DESCRIPTION
# Context:

There are no installation instructions for the Ubuntu OS, making it difficult to starting with Teresa right away.

# What was Done:

- Add `install` folder w/ an Ubuntu installation script;
- Update the `README` file to expose the script.