### PR TITLE
Add support to create more than one web app per Procfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [NEXT_RELEASE]
 ### Added
 - Validation for env var and secret names
+- Support to create more than one web app per code base
 
 ## [0.26.0]
 ### Added

--- a/FAQ.md
+++ b/FAQ.md
@@ -113,8 +113,8 @@ No, it's one process per app.
 For each app add a Procfile entry respecting the restrictions:
 
 * process types can't be repeated
-* `web`, `release` and `cron*` process types are special: `web` is the only
-  process type that creates an external endpoint, `cron*` is used for cronjobs
+* `web*`, `release` and `cron*` process types are special: `web*` are the only
+  process types that create an external endpoint, `cron*` is used for cronjobs
   and `release` for one off tasks after deploys.
 
 When creating the apps use the flag `process-type` to select the appropriate
@@ -129,7 +129,7 @@ Apps creation:
     $ teresa app create app2 --process-type worker --team <team-name>
 
 There's nothing special with the name `worker`, it can be anything different
-from `web` with a matching `Procfile` line. The two apps are deployed
+from `web*` with a matching `Procfile` line. The two apps are deployed
 separately (assuming you are at the shared repo root directory):
 
     $ teresa deploy create . --app app1 --description 'v1.0.0'
@@ -161,7 +161,7 @@ Note: it will implicitly create a new deploy.
 
 **Q: How to create an app without an endpoint (a worker for example)?**
 
-Use any name different from `web` as the process type:
+Use any name different from `web*` as the process type:
 
     $ teresa app create <app-name> --team <team-name> --process-type worker
 
@@ -172,7 +172,7 @@ You also have to adjust the `Procfile` to have a corresponding `worker` key.
     $ teresa app create <app-name> --team <team-name> --internal
 
 The app is only visible inside the cluster. The flag `--internal` only works
-with the `web` process type (the default).
+with the `web*` process types (`web` is the default).
 
 **Q: Where can I get some hello world examples?**
 

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -117,7 +117,7 @@ func (ops *AppOperations) Create(user *database.User, app *App) (Err error) {
 		return auth.ErrPermissionDenied
 	}
 
-	if ops.kops.IngressEnabled() && app.VirtualHost == "" && app.ProcessType == ProcessTypeWeb {
+	if ops.kops.IngressEnabled() && app.VirtualHost == "" && IsWebApp(app.ProcessType) {
 		return ErrMissingVirtualHost
 	}
 
@@ -749,6 +749,10 @@ func (ops *AppOperations) translateError(err error) error {
 	default:
 		return teresa_errors.NewInternalServerError(err)
 	}
+}
+
+func IsWebApp(processType string) bool {
+	return strings.HasPrefix(processType, ProcessTypeWeb)
 }
 
 func NewOperations(tops team.Operations, kops K8sOperations, st st.Storage) Operations {

--- a/pkg/server/app/models.go
+++ b/pkg/server/app/models.go
@@ -125,7 +125,7 @@ func newApp(req *appb.CreateRequest) *App {
 		processType = ProcessTypeWeb
 	}
 	protocol := req.Protocol
-	if processType == ProcessTypeWeb && protocol == "" {
+	if IsWebApp(processType) && protocol == "" {
 		protocol = defaultAppProtocol
 	}
 

--- a/pkg/server/build/build.go
+++ b/pkg/server/build/build.go
@@ -194,7 +194,7 @@ func (ops *BuildOperations) runInternal(ctx context.Context, a *app.App, buildNa
 		WithArgs([]string{"start", a.ProcessType}).
 		Build()
 
-	if a.ProcessType == app.ProcessTypeWeb {
+	if app.IsWebApp(a.ProcessType) {
 		fmt.Fprintln(w, "\nExposing temporary service")
 		url, err := ops.createService(a.Name, buildName, podSpec.Labels)
 		if err != nil {

--- a/pkg/server/deploy/deploy.go
+++ b/pkg/server/deploy/deploy.go
@@ -153,7 +153,7 @@ func (ops *DeployOperations) createOrUpdateDeploy(a *app.App, confFiles *DeployC
 		WithStorage(ops.fileStorage).
 		WithArgs([]string{"start", a.ProcessType})
 
-	if confFiles.NginxConf != "" && a.ProcessType == app.ProcessTypeWeb {
+	if confFiles.NginxConf != "" && app.IsWebApp(a.ProcessType) {
 		data := map[string]string{spec.NginxConfFile: confFiles.NginxConf}
 		if err := ops.k8s.CreateOrUpdateConfigMap(a.Name, a.Name, data); err != nil {
 			log.WithError(err).Errorf("Creating config to nginx of app %s", a.Name)
@@ -221,7 +221,7 @@ func (ops *DeployOperations) createOrUpdateCronJob(a *app.App, confFiles *Deploy
 }
 
 func (ops *DeployOperations) exposeApp(a *app.App, w io.Writer) error {
-	if a.ProcessType != app.ProcessTypeWeb {
+	if !app.IsWebApp(a.ProcessType) {
 		return nil
 	}
 	svcType := ops.serviceType(a)

--- a/pkg/server/deploy/deploy_test.go
+++ b/pkg/server/deploy/deploy_test.go
@@ -492,6 +492,8 @@ func TestExposeApp(t *testing.T) {
 		{app.ProcessTypeWeb, nil, true},
 		{app.ProcessTypeWeb, nil, true},
 		{app.ProcessTypeWeb, errors.New("some sad error"), true},
+		{app.ProcessTypeWeb + "test", nil, true},
+		{app.ProcessTypeWeb + "-test", nil, true},
 		{"worker", nil, false},
 	}
 

--- a/pkg/server/spec/runner.go
+++ b/pkg/server/spec/runner.go
@@ -37,7 +37,7 @@ func (b *RunnerPodBuilder) newAppRunnerContainer() *Container {
 		WithSecrets(b.app.Secrets).
 		WithArgs(b.args)
 
-	if b.app.ProcessType == app.ProcessTypeWeb {
+	if app.IsWebApp(b.app.ProcessType) {
 		builder = builder.
 			WithEnv(map[string]string{"PORT": strconv.Itoa(DefaultPort)}).
 			ExposePort("http", DefaultPort)


### PR DESCRIPTION
A process type is web like if it has the prefix `web`
(ex. `web`, `web-a`, `webapi`, etc)