### PR TITLE
Added ingress class annotation

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -110,6 +110,9 @@ Parameter | Description | Default
 `rbac.enabled` | If true, this configure teresa deployment to use rbac, for now it will use the `cluster-admin` role | `false`
 `apps.ingress` | If true, teresa will create a ingress when expose the app | `false`
 `apps.service_type` | The type used to create the app server | `LoadBalancer`
+`apps.ingress_class` | The ingress class to be used | ``
+`slugstore.image`| The image to be used for the slugstore | `""`
+`slugbuilder.image`| The image to be used for the slugbuilder | `""`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/helm/chart/teresa/templates/deployment.yaml
+++ b/helm/chart/teresa/templates/deployment.yaml
@@ -147,6 +147,8 @@ spec:
           value: {{ .Values.apps.ingress | quote}}
         - name: TERESA_DEPLOY_DEFAULT_SERVICE_TYPE
           value: {{ .Values.apps.service_type }}
+        - name: TERESA_DEPLOY_INGRESS_CLASS
+          value: {{ .Values.apps.ingress_class }}
         volumeMounts:
         {{- if .Values.tls.crt }}
         - mountPath: /etc/teresa

--- a/helm/chart/teresa/values.yaml
+++ b/helm/chart/teresa/values.yaml
@@ -43,6 +43,7 @@ rbac:
 apps:
   ingress: false
   service_type: LoadBalancer
+  ingress_class:
 slugstore:
   image:
 slugbuilder:

--- a/pkg/server/deploy/deploy.go
+++ b/pkg/server/deploy/deploy.go
@@ -38,7 +38,7 @@ type Operations interface {
 type K8sOperations interface {
 	CreateOrUpdateDeploy(deploySpec *spec.Deploy) error
 	CreateOrUpdateCronJob(cronJobSpec *spec.CronJob) error
-	ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, reserveStaticIp bool, w io.Writer) error
+	ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, reserveStaticIp bool, ingressClass string, w io.Writer) error
 	ReplicaSetListByLabel(namespace, label, value string) ([]*ReplicaSetListItem, error)
 	DeployRollbackToRevision(namespace, name, revision string) error
 	CreateOrUpdateConfigMap(namespace, name string, data map[string]string) error
@@ -234,7 +234,7 @@ func (ops *DeployOperations) exposeApp(a *app.App, w io.Writer) error {
 	}
 	svcType := ops.serviceType(a)
 	vHosts := strings.Split(a.VirtualHost, ",")
-	if err := ops.k8s.ExposeDeploy(a.Name, a.Name, svcType, a.Protocol, vHosts, a.ReserveStaticIp, w); err != nil {
+	if err := ops.k8s.ExposeDeploy(a.Name, a.Name, svcType, a.Protocol, vHosts, a.ReserveStaticIp, ops.opts.IngressClass, w); err != nil {
 		return err
 	}
 	if a.ReserveStaticIp {

--- a/pkg/server/deploy/deploy_test.go
+++ b/pkg/server/deploy/deploy_test.go
@@ -62,7 +62,7 @@ func (f *fakeK8sOperations) CreateOrUpdateCronJob(cronJobSpec *spec.CronJob) err
 	return f.createCronJobReturn
 }
 
-func (f *fakeK8sOperations) ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, reserveStaticIp bool, w io.Writer) error {
+func (f *fakeK8sOperations) ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, reserveStaticIp bool, ingressClass string, w io.Writer) error {
 	f.exposeDeployWasCalled = true
 	return nil
 }

--- a/pkg/server/deploy/handlers.go
+++ b/pkg/server/deploy/handlers.go
@@ -26,6 +26,7 @@ type Options struct {
 	BuildLimitMemory     string        `split_words:"true" default:"1Gi"`
 	DefaultServiceType   string        `split_words:"true" default:"LoadBalancer"`
 	CloudSQLProxyImage   string        `split_words:"true" default:"gcr.io/cloudsql-docker/gce-proxy:1.11"`
+	IngressClass         string        `split_words:"true" default:""`
 }
 
 type Service struct {


### PR DESCRIPTION
This is needed, specially on GKE, where you might have two classes of ingress controllers but you are using only one (e.g. nginx ingress). 

This PR might affect existing ingresses though! However, it won't overwrite it to null.