### PR TITLE
Expand lifecycle and probes to sidecars

### DIFF
--- a/pkg/server/k8s/converters.go
+++ b/pkg/server/k8s/converters.go
@@ -134,9 +134,9 @@ func podSpecToK8sPod(podSpec *spec.Pod) (*k8sv1.Pod, error) {
 	}
 
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyNever,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyNever,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
 	}
@@ -160,17 +160,19 @@ func deploySpecToK8sDeploy(deploySpec *spec.Deploy, replicas int32) (*v1beta2.De
 	}
 	volumes := podSpecVolumesToK8sVolumes(deploySpec.Volumes)
 
-	if deploySpec.HealthCheck != nil {
-		if deploySpec.HealthCheck.Liveness != nil {
-			containers[0].LivenessProbe = healthCheckProbeToK8sProbe(deploySpec.HealthCheck.Liveness)
+	for i, _ := range containers {
+		if deploySpec.HealthCheck != nil {
+			if deploySpec.HealthCheck.Liveness != nil {
+				containers[i].LivenessProbe = healthCheckProbeToK8sProbe(deploySpec.HealthCheck.Liveness)
+			}
+			if deploySpec.HealthCheck.Readiness != nil {
+				containers[i].ReadinessProbe = healthCheckProbeToK8sProbe(deploySpec.HealthCheck.Readiness)
+			}
 		}
-		if deploySpec.HealthCheck.Readiness != nil {
-			containers[0].ReadinessProbe = healthCheckProbeToK8sProbe(deploySpec.HealthCheck.Readiness)
-		}
-	}
 
-	if deploySpec.Lifecycle != nil {
-		containers[0].Lifecycle = lifecycleToK8sLifecycle(deploySpec.Lifecycle)
+		if deploySpec.Lifecycle != nil {
+			containers[i].Lifecycle = lifecycleToK8sLifecycle(deploySpec.Lifecycle)
+		}
 	}
 
 	f := false
@@ -179,9 +181,9 @@ func deploySpecToK8sDeploy(deploySpec *spec.Deploy, replicas int32) (*v1beta2.De
 		return nil, err
 	}
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyAlways,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyAlways,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
 	}
@@ -252,9 +254,9 @@ func cronJobSpecToK8sCronJob(cronJobSpec *spec.CronJob) (*k8sv1beta1.CronJob, er
 
 	f := false
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyNever,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyNever,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
 	}

--- a/pkg/server/k8s/converters_test.go
+++ b/pkg/server/k8s/converters_test.go
@@ -269,6 +269,13 @@ func TestDeploySpecToK8sDeploy(t *testing.T) {
 				Ports: []spec.Port{{
 					ContainerPort: 5000,
 				}},
+			}, {
+				Name:  "Sidecar",
+				Image: "sidecar/sidecar:latest",
+				Args:  []string{"sidecar"},
+				Ports: []spec.Port{{
+					ContainerPort: 4000,
+				}},
 			}},
 			InitContainers: []*spec.Container{{
 				Name:  "Teresa",
@@ -289,21 +296,23 @@ func TestDeploySpecToK8sDeploy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error to convert spec %v", err)
 	}
-	if len(k8sDeploy.Spec.Template.Spec.Containers) != 1 {
-		t.Fatalf("expected 1 container, got %d", len(k8sDeploy.Spec.Template.Spec.Containers))
-	}
-	c := k8sDeploy.Spec.Template.Spec.Containers[0]
-	for idx, arg := range ds.Containers[0].Args {
-		if c.Args[idx] != arg {
-			t.Errorf("expected %s, got %s", arg, c.Args[idx])
-		}
+	if len(k8sDeploy.Spec.Template.Spec.Containers) != 2 {
+		t.Fatalf("expected 2 container, got %d", len(k8sDeploy.Spec.Template.Spec.Containers))
 	}
 
-	if c.LivenessProbe.PeriodSeconds != ds.HealthCheck.Liveness.PeriodSeconds {
-		t.Errorf("expected %d, got %d", ds.HealthCheck.Liveness.PeriodSeconds, c.LivenessProbe.PeriodSeconds)
-	}
-	if c.ReadinessProbe.PeriodSeconds != ds.HealthCheck.Readiness.PeriodSeconds {
-		t.Errorf("expected %d, got %d", ds.HealthCheck.Readiness.PeriodSeconds, c.ReadinessProbe.PeriodSeconds)
+	for i, c := range k8sDeploy.Spec.Template.Spec.Containers {
+		for idx, arg := range ds.Containers[i].Args {
+			if c.Args[idx] != arg {
+				t.Errorf("expected %s, got %s", arg, c.Args[idx])
+			}
+		}
+
+		if c.LivenessProbe.PeriodSeconds != ds.HealthCheck.Liveness.PeriodSeconds {
+			t.Errorf("expected %d, got %d", ds.HealthCheck.Liveness.PeriodSeconds, c.LivenessProbe.PeriodSeconds)
+		}
+		if c.ReadinessProbe.PeriodSeconds != ds.HealthCheck.Readiness.PeriodSeconds {
+			t.Errorf("expected %d, got %d", ds.HealthCheck.Readiness.PeriodSeconds, c.ReadinessProbe.PeriodSeconds)
+		}
 	}
 
 	k8sReplicas := k8sDeploy.Spec.Replicas
@@ -601,9 +610,9 @@ func TestK8sServiceToService(t *testing.T) {
 			Namespace: namespace,
 		},
 		Spec: k8sv1.ServiceSpec{
-			Type: k8sv1.ServiceType(svcType),
+			Type:                     k8sv1.ServiceType(svcType),
 			LoadBalancerSourceRanges: ranges,
-			Ports: []k8sv1.ServicePort{{}},
+			Ports:                    []k8sv1.ServicePort{{}},
 		},
 	}
 	svc := k8sServiceToService(k8sSvc)


### PR DESCRIPTION
If applied, this PR expands the liveness, readiness and lifecycle to sidecars, such as the NGINX sidecar  or the CloudSQL Proxy sidecar. 

However, it can be harmful for deployments using CloudSQL Proxy, as the liveness/readiness probe might not work for it. 