### PR TITLE
dnsConfig - Set ndots 2 hard coded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,9 @@ ENV/
 
 #Helm Dependency
 helm/chart/teresa/charts
+
+.idea
+.vscode
+teresa-server
+cmd/client/client
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.29.0] - 2018-04-29
 ### Added
 - One click way to delete app silently with --no-input flag
 

--- a/helm/chart/teresa/Chart.yaml
+++ b/helm/chart/teresa/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart to deploy teresa on Kubernetes
 name: teresa
-version: 0.28.0
+version: 0.29.0
 sources:
   - https://github.com/luizalabs/teresa

--- a/helm/chart/teresa/values.yaml
+++ b/helm/chart/teresa/values.yaml
@@ -25,7 +25,7 @@ aws:
 docker:
   registry: luizalabs
   image: teresa
-  tag: v0.28.0
+  tag: v0.29.0
 build:
   limits:
     cpu: 500m

--- a/pkg/server/k8s/converters.go
+++ b/pkg/server/k8s/converters.go
@@ -134,9 +134,9 @@ func podSpecToK8sPod(podSpec *spec.Pod) (*k8sv1.Pod, error) {
 	}
 
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyNever,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyNever,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
 	}
@@ -179,11 +179,12 @@ func deploySpecToK8sDeploy(deploySpec *spec.Deploy, replicas int32) (*v1beta2.De
 		return nil, err
 	}
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyAlways,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyAlways,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
+		DNSConfig:                    dnsConfigToK8sDNSConfig(deploySpec.DNSConfig),
 	}
 
 	var maxSurge, maxUnavailable *intstr.IntOrString
@@ -252,9 +253,9 @@ func cronJobSpecToK8sCronJob(cronJobSpec *spec.CronJob) (*k8sv1beta1.CronJob, er
 
 	f := false
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyNever,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyNever,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
 	}
@@ -331,6 +332,21 @@ func lifecycleToK8sLifecycle(lc *spec.Lifecycle) *k8sv1.Lifecycle {
 	}
 
 	return k8sLc
+}
+
+func dnsConfigToK8sDNSConfig(dc *spec.DNSConfig) *k8sv1.PodDNSConfig {
+	k8sDc := new(k8sv1.PodDNSConfig)
+
+	if dc != nil {
+		k8sDc = &k8sv1.PodDNSConfig{
+			Options: append([]k8sv1.PodDNSConfigOption{}, k8sv1.PodDNSConfigOption{
+				Name:  dc.Options[0].Name,
+				Value: &dc.Options[0].Value,
+			}),
+		}
+	}
+
+	return k8sDc
 }
 
 func serviceSpecToK8s(svcSpec *spec.Service) *k8sv1.Service {

--- a/pkg/server/spec/deploy.go
+++ b/pkg/server/spec/deploy.go
@@ -45,10 +45,20 @@ type TeresaYaml struct {
 	Lifecycle     *Lifecycle         `yaml:"lifecycle,omitempty"`
 	Cron          *CronArgs          `yaml:"cron,omitempty"`
 	SideCars      map[string]RawData `yaml:"sidecars,omitempty"`
+	DNSConfig     *DNSConfig
 }
 
 type TeresaYamlV2 struct {
 	Applications map[string]*TeresaYaml `yaml:"applications,omitempty"`
+}
+
+type DNSConfig struct {
+	Options []DNSOptions
+}
+
+type DNSOptions struct {
+	Name  string
+	Value string
 }
 
 type Deploy struct {
@@ -112,6 +122,16 @@ func (b *DeployBuilder) Build() *Deploy {
 			PreStop: &PreStop{DrainTimeoutSeconds: defaultDrainTimeoutSeconds},
 		}
 	}
+
+	if b.d.DNSConfig == nil {
+		b.d.DNSConfig = &DNSConfig{
+			Options: append([]DNSOptions{}, DNSOptions{
+				Name:  "ndots",
+				Value: "2",
+			}),
+		}
+	}
+
 	return b.d
 }
 

--- a/pkg/server/spec/deploy_test.go
+++ b/pkg/server/spec/deploy_test.go
@@ -60,6 +60,10 @@ func TestDeployBuilder(t *testing.T) {
 	if ds.Lifecycle.PreStop.DrainTimeoutSeconds != defaultDrainTimeoutSeconds {
 		t.Errorf("got %d; want %d", ds.Lifecycle.PreStop.DrainTimeoutSeconds, defaultDrainTimeoutSeconds)
 	}
+
+	if ds.DNSConfig == nil {
+		t.Errorf("expected dnsConfig; got nil")
+	}
 }
 
 func TestRawData(t *testing.T) {


### PR DESCRIPTION
https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html

Due to bad performance on ndots 5, we decided to set ndots 2 when creating a app or deploying an existed app.