### PR TITLE
ndots 2 hardcoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,9 @@ ENV/
 
 #Helm Dependency
 helm/chart/teresa/charts
+
+.idea
+.vscode
+teresa-server
+cmd/client/client
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [next_version] - 2020-02-03
+### Changed
+- Added dnsConfig on deploy
+
 ## [0.31.0] - 2019-12-06
 ### Changed
 - Updated minio version on helm chart

--- a/helm/chart/teresa/templates/deployment.yaml
+++ b/helm/chart/teresa/templates/deployment.yaml
@@ -149,6 +149,10 @@ spec:
           value: {{ .Values.apps.service_type }}
         - name: TERESA_DEPLOY_INGRESS_CLASS
           value: {{ .Values.apps.ingress_class }}
+        {{- if .Values.apps.dnsconfig_ndots }}
+        - name: TERESA_DEPLOY_DNSCONFIG_NDOTS
+          value: {{ .Values.apps.dnsconfig_ndots }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.tls.crt }}
         - mountPath: /etc/teresa

--- a/pkg/server/deploy/deploy.go
+++ b/pkg/server/deploy/deploy.go
@@ -186,6 +186,7 @@ func (ops *DeployOperations) createOrUpdateDeploy(a *app.App, confFiles *DeployC
 		WithDescription(description).
 		WithRevisionHistoryLimit(ops.opts.RevisionHistoryLimit).
 		WithTeresaYaml(confFiles.TeresaYaml).
+		WithDNSConfigNdots(ops.opts.DNSConfigNdots).
 		WithMatchLabels(labels).
 		Build()
 

--- a/pkg/server/deploy/handlers.go
+++ b/pkg/server/deploy/handlers.go
@@ -27,6 +27,7 @@ type Options struct {
 	DefaultServiceType   string        `split_words:"true" default:"LoadBalancer"`
 	CloudSQLProxyImage   string        `split_words:"true" default:"gcr.io/cloudsql-docker/gce-proxy:1.11"`
 	IngressClass         string        `split_words:"true" default:""`
+	DNSConfigNdots       string        `envconfig:"dnsconfig_ndots" default:"2"`
 }
 
 type Service struct {

--- a/pkg/server/k8s/converters.go
+++ b/pkg/server/k8s/converters.go
@@ -134,9 +134,9 @@ func podSpecToK8sPod(podSpec *spec.Pod) (*k8sv1.Pod, error) {
 	}
 
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyNever,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyNever,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
 	}
@@ -179,11 +179,12 @@ func deploySpecToK8sDeploy(deploySpec *spec.Deploy, replicas int32) (*v1beta2.De
 		return nil, err
 	}
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyAlways,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyAlways,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
+		DNSConfig:                    dnsConfigToK8sDNSConfig(deploySpec.DNSConfig),
 	}
 
 	var maxSurge, maxUnavailable *intstr.IntOrString
@@ -252,9 +253,9 @@ func cronJobSpecToK8sCronJob(cronJobSpec *spec.CronJob) (*k8sv1beta1.CronJob, er
 
 	f := false
 	ps := k8sv1.PodSpec{
-		RestartPolicy: k8sv1.RestartPolicyNever,
-		Containers:    containers,
-		Volumes:       volumes,
+		RestartPolicy:                k8sv1.RestartPolicyNever,
+		Containers:                   containers,
+		Volumes:                      volumes,
 		AutomountServiceAccountToken: &f,
 		InitContainers:               initContainers,
 	}
@@ -331,6 +332,21 @@ func lifecycleToK8sLifecycle(lc *spec.Lifecycle) *k8sv1.Lifecycle {
 	}
 
 	return k8sLc
+}
+
+func dnsConfigToK8sDNSConfig(dc *spec.DNSConfig) *k8sv1.PodDNSConfig {
+	k8sDc := new(k8sv1.PodDNSConfig)
+
+	if dc != nil {
+		k8sDc = &k8sv1.PodDNSConfig{
+			Options: append([]k8sv1.PodDNSConfigOption{}, k8sv1.PodDNSConfigOption{
+				Name:  dc.Options[0].Name,
+				Value: &dc.Options[0].Value,
+			}),
+		}
+	}
+
+	return k8sDc
 }
 
 func serviceSpecToK8s(svcSpec *spec.Service) *k8sv1.Service {

--- a/pkg/server/spec/deploy.go
+++ b/pkg/server/spec/deploy.go
@@ -106,6 +106,20 @@ func (b *DeployBuilder) WithRevisionHistoryLimit(rhl int) *DeployBuilder {
 	return b
 }
 
+func (b *DeployBuilder) WithDNSConfigNdots(ndots string) *DeployBuilder {
+
+	if b.d.DNSConfig == nil {
+		b.d.DNSConfig = &DNSConfig{
+			Options: append([]DNSOptions{}, DNSOptions{
+				Name:  "ndots",
+				Value: ndots,
+			}),
+		}
+	}
+
+	return b
+}
+
 func (b *DeployBuilder) WithDescription(desc string) *DeployBuilder {
 	b.d.Description = desc
 	return b
@@ -120,15 +134,6 @@ func (b *DeployBuilder) Build() *Deploy {
 	if b.d.Lifecycle == nil {
 		b.d.Lifecycle = &Lifecycle{
 			PreStop: &PreStop{DrainTimeoutSeconds: defaultDrainTimeoutSeconds},
-		}
-	}
-
-	if b.d.DNSConfig == nil {
-		b.d.DNSConfig = &DNSConfig{
-			Options: append([]DNSOptions{}, DNSOptions{
-				Name:  "ndots",
-				Value: "2",
-			}),
 		}
 	}
 

--- a/pkg/server/spec/deploy.go
+++ b/pkg/server/spec/deploy.go
@@ -45,10 +45,20 @@ type TeresaYaml struct {
 	Lifecycle     *Lifecycle         `yaml:"lifecycle,omitempty"`
 	Cron          *CronArgs          `yaml:"cron,omitempty"`
 	SideCars      map[string]RawData `yaml:"sidecars,omitempty"`
+	DNSConfig     *DNSConfig
 }
 
 type TeresaYamlV2 struct {
 	Applications map[string]*TeresaYaml `yaml:"applications,omitempty"`
+}
+
+type DNSConfig struct {
+	Options []DNSOptions
+}
+
+type DNSOptions struct {
+	Name  string
+	Value string
 }
 
 type Deploy struct {
@@ -112,6 +122,16 @@ func (b *DeployBuilder) Build() *Deploy {
 			PreStop: &PreStop{DrainTimeoutSeconds: defaultDrainTimeoutSeconds},
 		}
 	}
+
+	if b.d.DNSConfig == nil {
+		b.d.DNSConfig = &DNSConfig{
+			Options: append([]DNSOptions{}, DNSOptions{
+				Name:  "ndots",
+				Value: "2",
+			}),
+		}
+	}
+
 	return b.d
 }
 

--- a/pkg/server/spec/deploy.go
+++ b/pkg/server/spec/deploy.go
@@ -45,7 +45,7 @@ type TeresaYaml struct {
 	Lifecycle     *Lifecycle         `yaml:"lifecycle,omitempty"`
 	Cron          *CronArgs          `yaml:"cron,omitempty"`
 	SideCars      map[string]RawData `yaml:"sidecars,omitempty"`
-	DNSConfig     *DNSConfig
+	DNSConfig     *DNSConfig         `yaml:"dnsConfig,omitempty"`
 }
 
 type TeresaYamlV2 struct {
@@ -53,12 +53,12 @@ type TeresaYamlV2 struct {
 }
 
 type DNSConfig struct {
-	Options []DNSOptions
+	Options []DNSOptions `yaml:"options"`
 }
 
 type DNSOptions struct {
-	Name  string
-	Value string
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
 }
 
 type Deploy struct {

--- a/pkg/server/spec/deploy_test.go
+++ b/pkg/server/spec/deploy_test.go
@@ -62,7 +62,30 @@ func TestDeployBuilder(t *testing.T) {
 	}
 
 	if ds.DNSConfig == nil {
-		t.Errorf("expected dnsConfig; got nil")
+		t.Error("expected dnsConfig; got nil")
+	}
+
+	if ds.DNSConfig.Options[0].Value != "2" {
+		t.Errorf("expected dnsConfig.Options[0].value to be 2; got %s", ds.DNSConfig.Options[0].Value)
+	}
+}
+
+func TestTeresaYamlOvewriteNdots(t *testing.T) {
+	expectedSlugURL := "some/slug.tgz"
+	teresaYaml := &TeresaYaml{}
+	teresaYaml.DNSConfig = &DNSConfig{
+		Options: append([]DNSOptions{}, DNSOptions{
+			Name:  "ndots",
+			Value: "1",
+		}),
+	}
+
+	ds := NewDeployBuilder(expectedSlugURL).
+		WithTeresaYaml(teresaYaml).
+		Build()
+
+	if ds.DNSConfig.Options[0].Value != "1" {
+		t.Errorf("expected dnsConfig.Options[0].value to be 1; got %s", ds.DNSConfig.Options[0].Value)
 	}
 }
 

--- a/pkg/server/spec/deploy_test.go
+++ b/pkg/server/spec/deploy_test.go
@@ -21,11 +21,13 @@ func TestDeployBuilder(t *testing.T) {
 	expectedDescription := "teste"
 	expectedRevisionHistoryLimit := 5
 	expectedMatchLabels := map[string]string{"expected": "label"}
+	expectedDNSConfigNdots := "2"
 	ds := NewDeployBuilder(expectedSlugURL).
 		WithPod(pod).
 		WithDescription(expectedDescription).
 		WithRevisionHistoryLimit(expectedRevisionHistoryLimit).
 		WithTeresaYaml(&TeresaYaml{}).
+		WithDNSConfigNdots(expectedDNSConfigNdots).
 		WithMatchLabels(expectedMatchLabels).
 		Build()
 
@@ -71,6 +73,7 @@ func TestDeployBuilder(t *testing.T) {
 }
 
 func TestTeresaYamlOvewriteNdots(t *testing.T) {
+	expectedDNSConfigNdots := "2"
 	expectedSlugURL := "some/slug.tgz"
 	teresaYaml := &TeresaYaml{}
 	teresaYaml.DNSConfig = &DNSConfig{
@@ -82,6 +85,7 @@ func TestTeresaYamlOvewriteNdots(t *testing.T) {
 
 	ds := NewDeployBuilder(expectedSlugURL).
 		WithTeresaYaml(teresaYaml).
+		WithDNSConfigNdots(expectedDNSConfigNdots).
 		Build()
 
 	if ds.DNSConfig.Options[0].Value != "1" {

--- a/pkg/server/spec/deploy_test.go
+++ b/pkg/server/spec/deploy_test.go
@@ -60,6 +60,10 @@ func TestDeployBuilder(t *testing.T) {
 	if ds.Lifecycle.PreStop.DrainTimeoutSeconds != defaultDrainTimeoutSeconds {
 		t.Errorf("got %d; want %d", ds.Lifecycle.PreStop.DrainTimeoutSeconds, defaultDrainTimeoutSeconds)
 	}
+
+	if ds.DNSConfig == nil {
+		t.Errorf("expected dnsConfig; got nil")
+	}
 }
 
 func TestRawData(t *testing.T) {


### PR DESCRIPTION
https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html

Due to bad performance of ndots 5, we decided to set ndots 2 in every deploy and app creation