### PR TITLE
This PR simplifies ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [NEXT_RELEASE]
 ### Changed
 - Default nginx side-car image to allow support to lua scripts
+- Ingress spec will be the same for vhost and static IP
 
 ## [0.32.0]
 ### Changed

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -77,7 +77,7 @@ type K8sOperations interface {
 	DeletePod(namespace, podName string) error
 	HasIngress(namespace, name string) (bool, error)
 	IngressEnabled() bool
-	UpdateIngress(namespace, name string, vHosts []string, reserveStaticIp bool) error
+	UpdateIngress(namespace, name string, vHosts []string) error
 	CreateOrUpdateDeploySecretFile(namespace, deploy, fileName string) error
 	CreateOrUpdateCronJobSecretFile(namespace, cronjob, filename string) error
 	DeleteDeploySecrets(namespace, deploy string, envVars, volKeys []string) error
@@ -726,7 +726,7 @@ func (ops *AppOperations) SetVHosts(user *database.User, appName string, vHosts 
 	}
 
 	if hasIngress {
-		if err := ops.kops.UpdateIngress(appName, appName, vHosts, false); err != nil {
+		if err := ops.kops.UpdateIngress(appName, appName, vHosts); err != nil {
 			return teresa_errors.NewInternalServerError(err)
 		}
 	}

--- a/pkg/server/app/app_test.go
+++ b/pkg/server/app/app_test.go
@@ -265,7 +265,7 @@ func (f *fakeK8sOperations) ResumeCronJob(namespace, name string) error {
 	return f.ResumeCronJobErr
 }
 
-func (f *fakeK8sOperations) UpdateIngress(namespace, name string, vHosts []string, reserveStaticIp bool) error {
+func (f *fakeK8sOperations) UpdateIngress(namespace, name string, vHosts []string) error {
 	return f.UpdateIngressErr
 }
 

--- a/pkg/server/deploy/deploy.go
+++ b/pkg/server/deploy/deploy.go
@@ -38,7 +38,7 @@ type Operations interface {
 type K8sOperations interface {
 	CreateOrUpdateDeploy(deploySpec *spec.Deploy) error
 	CreateOrUpdateCronJob(cronJobSpec *spec.CronJob) error
-	ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, reserveStaticIp bool, ingressClass string, w io.Writer) error
+	ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, ingressClass string, w io.Writer) error
 	ReplicaSetListByLabel(namespace, label, value string) ([]*ReplicaSetListItem, error)
 	DeployRollbackToRevision(namespace, name, revision string) error
 	CreateOrUpdateConfigMap(namespace, name string, data map[string]string) error
@@ -235,7 +235,7 @@ func (ops *DeployOperations) exposeApp(a *app.App, w io.Writer) error {
 	}
 	svcType := ops.serviceType(a)
 	vHosts := strings.Split(a.VirtualHost, ",")
-	if err := ops.k8s.ExposeDeploy(a.Name, a.Name, svcType, a.Protocol, vHosts, a.ReserveStaticIp, ops.opts.IngressClass, w); err != nil {
+	if err := ops.k8s.ExposeDeploy(a.Name, a.Name, svcType, a.Protocol, vHosts, ops.opts.IngressClass, w); err != nil {
 		return err
 	}
 	if a.ReserveStaticIp {

--- a/pkg/server/deploy/deploy_test.go
+++ b/pkg/server/deploy/deploy_test.go
@@ -62,7 +62,7 @@ func (f *fakeK8sOperations) CreateOrUpdateCronJob(cronJobSpec *spec.CronJob) err
 	return f.createCronJobReturn
 }
 
-func (f *fakeK8sOperations) ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, reserveStaticIp bool, ingressClass string, w io.Writer) error {
+func (f *fakeK8sOperations) ExposeDeploy(namespace, name, svcType, portName string, vHosts []string, ingressClass string, w io.Writer) error {
 	f.exposeDeployWasCalled = true
 	return nil
 }

--- a/pkg/server/k8s/client.go
+++ b/pkg/server/k8s/client.go
@@ -623,12 +623,12 @@ func (k *Client) HasIngress(namespace, appName string) (bool, error) {
 	return true, nil
 }
 
-func (k *Client) createIngress(namespace, appName string, vHosts []string, reserveStaticIp bool, ingressClass string) error {
+func (k *Client) createIngress(namespace, appName string, vHosts []string, ingressClass string) error {
 	kc, err := k.buildClient()
 	if err != nil {
 		return err
 	}
-	igsSpec := ingressSpec(namespace, appName, vHosts, reserveStaticIp)
+	igsSpec := ingressSpec(namespace, appName, vHosts)
 	_, err = kc.ExtensionsV1beta1().Ingresses(namespace).Create(igsSpec)
 	if err != nil {
 		return errors.Wrap(err, "create ingress failed")
@@ -644,7 +644,7 @@ func (k *Client) createIngress(namespace, appName string, vHosts []string, reser
 	return nil
 }
 
-func (k *Client) UpdateIngress(namespace, name string, vHosts []string, reserveStaticIp bool) error {
+func (k *Client) UpdateIngress(namespace, name string, vHosts []string) error {
 	kc, err := k.buildClient()
 	if err != nil {
 		return err
@@ -655,7 +655,7 @@ func (k *Client) UpdateIngress(namespace, name string, vHosts []string, reserveS
 	if err != nil {
 		return errors.Wrap(err, "get ingress failed")
 	}
-	newSpec := ingressSpec(namespace, name, vHosts, reserveStaticIp)
+	newSpec := ingressSpec(namespace, name, vHosts)
 	old.Spec.Rules = newSpec.Spec.Rules
 	_, err = kc.ExtensionsV1beta1().Ingresses(namespace).Update(old)
 	return errors.Wrap(err, "update ingress failed")
@@ -699,7 +699,7 @@ func (c *Client) IngressAnnotations(namespace, ingName string) (map[string]strin
 }
 
 // ExposeDeploy creates a service and/or a ingress if needed
-func (k *Client) ExposeDeploy(namespace, appName, svcType, portName string, vHosts []string, reserveStaticIp bool, ingressClass string, w io.Writer) error {
+func (k *Client) ExposeDeploy(namespace, appName, svcType, portName string, vHosts []string, ingressClass string, w io.Writer) error {
 	hasSrv, err := k.hasService(namespace, appName)
 	if err != nil {
 		return err
@@ -721,7 +721,7 @@ func (k *Client) ExposeDeploy(namespace, appName, svcType, portName string, vHos
 	}
 	if !hasIgs {
 		fmt.Fprintln(w, "Creating ingress")
-		if err := k.createIngress(namespace, appName, vHosts, reserveStaticIp, ingressClass); err != nil {
+		if err := k.createIngress(namespace, appName, vHosts, ingressClass); err != nil {
 			return err
 		}
 	}

--- a/pkg/server/k8s/converters.go
+++ b/pkg/server/k8s/converters.go
@@ -370,13 +370,8 @@ func serviceSpecToK8s(svcSpec *spec.Service) *k8sv1.Service {
 	}
 }
 
-func ingressSpec(namespace, name string, vHosts []string, reserveStaticIp bool) *k8s_extensions.Ingress {
-	var rules []k8s_extensions.IngressRule
-	if reserveStaticIp && len(vHosts) == 0 {
-		rules = make([]k8s_extensions.IngressRule, 1)
-	} else {
-		rules = make([]k8s_extensions.IngressRule, len(vHosts))
-	}
+func ingressSpec(namespace, name string, vHosts []string) *k8s_extensions.Ingress {
+	rules := make([]k8s_extensions.IngressRule, len(vHosts))
 
 	backend := &k8s_extensions.IngressBackend{
 		ServiceName: name,
@@ -399,15 +394,8 @@ func ingressSpec(namespace, name string, vHosts []string, reserveStaticIp bool) 
 		}
 	}
 
-	var spec k8s_extensions.IngressSpec
-	if reserveStaticIp {
-		spec = k8s_extensions.IngressSpec{
-			Backend: backend,
-		}
-	} else {
-		spec = k8s_extensions.IngressSpec{
-			Rules: rules,
-		}
+	spec := k8s_extensions.IngressSpec{
+		Rules: rules,
 	}
 
 	return &k8s_extensions.Ingress{

--- a/pkg/server/k8s/converters_test.go
+++ b/pkg/server/k8s/converters_test.go
@@ -346,7 +346,7 @@ func TestIngressSpec(t *testing.T) {
 	namespace := "teresa"
 	vHosts := []string{"test1.teresa-apps.io", "test2.teresa-apps.io"}
 
-	i := ingressSpec(namespace, name, vHosts, false)
+	i := ingressSpec(namespace, name, vHosts)
 	if i.ObjectMeta.Name != name {
 		t.Errorf("expected %s, got %s", name, i.ObjectMeta.Name)
 	}
@@ -360,28 +360,6 @@ func TestIngressSpec(t *testing.T) {
 		if rule.Host != vHosts[idx] {
 			t.Errorf("expected %s, got %s", vHosts[idx], rule.Host)
 		}
-	}
-}
-
-func TestIngressSpecReserveStaticIp(t *testing.T) {
-	name := "teresa"
-	namespace := "teresa"
-
-	i := ingressSpec(namespace, name, []string{}, true)
-	if i.ObjectMeta.Name != name {
-		t.Errorf("expected %s, got %s", name, i.ObjectMeta.Name)
-	}
-	if i.ObjectMeta.Namespace != namespace {
-		t.Errorf("expected %s, got %s", namespace, i.ObjectMeta.Namespace)
-	}
-	if i.Spec.Rules != nil {
-		t.Errorf("expected nothing, got %s", i.Spec.Rules)
-	}
-	if i.Spec.Backend == nil {
-		t.Errorf("expected backend, got %s", i.Spec.Backend)
-	}
-	if i.Spec.Backend.ServiceName != name {
-		t.Errorf("expected %s, got %s", name, i.Spec.Backend.ServiceName)
 	}
 }
 
@@ -601,9 +579,9 @@ func TestK8sServiceToService(t *testing.T) {
 			Namespace: namespace,
 		},
 		Spec: k8sv1.ServiceSpec{
-			Type: k8sv1.ServiceType(svcType),
+			Type:                     k8sv1.ServiceType(svcType),
 			LoadBalancerSourceRanges: ranges,
-			Ports: []k8sv1.ServicePort{{}},
+			Ports:                    []k8sv1.ServicePort{{}},
 		},
 	}
 	svc := k8sServiceToService(k8sSvc)


### PR DESCRIPTION
When we were developing the Ingress support for GCE, we thought the Ingress spec had to be different. However, after testing the same spec we create for Vhost for a couple of months, we found out that there was no problem in using it. 