### PR TITLE
Adds rewrite-target annotation, tests for Nginx Annotations…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [NEXT_RELEASE]
 ### Added
 - Verification to avoid ingress duplication when an unmanaged ingress exists
+- Adds rewrite-target annotation to createIngress if ingressClass is nginx
 
 ### Changed
 - Default nginx side-car image to allow support to lua scripts
 - Ingress spec will be the same for vhost and static IP
 - Checks if app already has ingress before trying to reserve a static IP
+- Moves ingress annotations to deploy's exposeApp
 
 ### Fixed
 - Don't create an Ingress for apps without vHosts

--- a/pkg/server/k8s/client.go
+++ b/pkg/server/k8s/client.go
@@ -49,7 +49,9 @@ type Client struct {
 
 func (k *Client) buildClient() (kubernetes.Interface, error) {
 	if k.testing {
-		k.fake = fake.NewSimpleClientset()
+		if k.fake == nil {
+			k.fake = fake.NewSimpleClientset()
+		}
 		return k.fake, nil
 	}
 	c, err := kubernetes.NewForConfig(k.conf)
@@ -655,14 +657,6 @@ func (k *Client) createIngress(namespace, appName string, vHosts []string, ingre
 	_, err = kc.ExtensionsV1beta1().Ingresses(namespace).Create(igsSpec)
 	if err != nil {
 		return errors.Wrap(err, "create ingress failed")
-	}
-	if ingressClass != "" {
-		if err = k.SetIngressAnnotations(
-			namespace, appName,
-			map[string]string{"kubernetes.io/ingress.class": ingressClass},
-		); err != nil {
-			return errors.Wrap(err, "create ingress failed")
-		}
 	}
 	return nil
 }

--- a/pkg/server/k8s/client_test.go
+++ b/pkg/server/k8s/client_test.go
@@ -379,12 +379,12 @@ func TestHasAnotherIngress(t *testing.T) {
 	if err := cli.createIngress("test", "ingress2", []string{"xpto.com"}, "nginx"); err != nil {
 		t.Fatal("got unexpected error:", err)
 	}
-	rs, err := cli.HasAnotherIngress("test", "test")
+	hasAnotherIngress, err := cli.HasAnotherIngress("test", "test")
 	if err != nil {
 		t.Fatal("got unexpected error:", err)
 	}
 
-	if rs != true {
-		t.Errorf("got true; want false")
+	if hasAnotherIngress != true {
+		t.Errorf("hasAnotherIngress returned false; want true")
 	}
 }

--- a/pkg/server/k8s/client_test.go
+++ b/pkg/server/k8s/client_test.go
@@ -12,6 +12,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func setupK8sCli(t *testing.T, cli *Client) (func(t *testing.T, cli *Client), error) {
+	return func(t *testing.T, cli *Client) {
+		cli.fake = nil
+	}, nil
+}
+
 func TestAddVolumeMountOfSecrets(t *testing.T) {
 	var testCases = []struct {
 		vols       []k8sv1.VolumeMount
@@ -344,6 +350,8 @@ func TestRemoveSecretVols(t *testing.T) {
 func TestClientCreateNamespace(t *testing.T) {
 	a := &app.App{Name: "test"}
 	cli := &Client{testing: true}
+	teardownCli, err := setupK8sCli(t, cli)
+	defer teardownCli(t, cli)
 
 	if err := cli.CreateNamespace(a, "test"); err != nil {
 		t.Fatal("got unexpected error:", err)
@@ -361,6 +369,8 @@ func TestClientCreateNamespace(t *testing.T) {
 
 func TestHasAnotherIngress(t *testing.T) {
 	cli := &Client{testing: true}
+	teardownCli, err := setupK8sCli(t, cli)
+	defer teardownCli(t, cli)
 
 	if err := cli.createIngress("test", "ingress1", []string{"xpto.com"}, "nginx"); err != nil {
 		t.Fatal("got unexpected error:", err)
@@ -374,7 +384,7 @@ func TestHasAnotherIngress(t *testing.T) {
 		t.Fatal("got unexpected error:", err)
 	}
 
-	if rs != false {
+	if rs != true {
 		t.Errorf("got true; want false")
 	}
 }


### PR DESCRIPTION
This PR adds the `nginx.ingress.kubernetes.io/rewrite-target: /` when ingress class is nginx, adds tests for Nginx Annotations and attempts to create a singleton for building a kubernetes fake client.


Fixes #636 